### PR TITLE
Normalize explanation suffixes in text

### DIFF
--- a/scripts/extract_requirements_table.py
+++ b/scripts/extract_requirements_table.py
@@ -98,10 +98,14 @@ def _normalize_explanation_suffix_once(text: str) -> str:
         expl = m.group("expl").strip()
         if not expl:
             return m.group(0)
+        # If the value already contains a colon (e.g., "0x1: Active"),
+        # treat the comma suffix as an external annotation and do not convert
+        if ":" in val or "：" in val:
+            return m.group(0)
         return f"{head}{val}: {expl}"
 
     pattern_comma = re.compile(
-        _EXPL_HEAD_RE + r"(?P<val>[^,，()（）\"]+?)\s*[，,]\s*(?P<expl>[^()（）\"]*?)\s*(?=(?:&&|\|\||$))"
+        _EXPL_HEAD_RE + r"(?P<val>[^,，:：()（）\"]+?)\s*[，,]\s*(?P<expl>[^()（）\"]*?)\s*(?=(?:&&|\|\||$))"
     )
     s_new = pattern_comma.sub(repl_comma, s_new)
 


### PR DESCRIPTION
Prevent comma-separated explanation normalization from adding a second colon when the value already contains one.

---
<a href="https://cursor.com/background-agent?bcId=bc-125b99ef-c549-46c8-80fc-2d6f3003c778">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-125b99ef-c549-46c8-80fc-2d6f3003c778">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

