### PR TITLE
Parse and normalize conditional logic

### DIFF
--- a/scripts/extract_requirements_table.py
+++ b/scripts/extract_requirements_table.py
@@ -65,8 +65,8 @@ def _normalize_explanation_suffix_once(text: str) -> str:
         head = m.group("head")
         val = m.group("val")
         expl = m.group("expl").strip()
-        # Skip if explanation contains characters that usually denote options or operators
-        if any(ch in expl for ch in "/+|&"):  # e.g., (Resume/+)
+        # Skip only if explanation clearly contains boolean operators to avoid breaking expressions
+        if "&&" in expl or "||" in expl:
             return m.group(0)
         return f"{head}{val}: {expl}"
 


### PR DESCRIPTION
Adjust parentheses-explanation normalization to include `/` and `+` in explanations.

Previously, explanations within parentheses were skipped if they contained characters like `/` or `+`, leading to `(Resume/+)` not being normalized. This change ensures such content is correctly treated as an explanation, e.g., `{X}(Resume/+)` becomes `{X}: Resume/+`.

---
<a href="https://cursor.com/background-agent?bcId=bc-5c5fe0cb-9a5b-4be2-9061-29821e859769">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5c5fe0cb-9a5b-4be2-9061-29821e859769">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

