### PR TITLE
Parse conditional logic and results

### DIFF
--- a/sample_in.txt
+++ b/sample_in.txt
@@ -1,0 +1,5 @@
+2.3.2.5.22 CDP激活【D-SM-SWR2025061832】
+IF
+  {AutomaticBrakingActive}(CDP功能激活状态) == 0x1(Active) 
+THEN
+  {DA_Inhibit} = 5

--- a/sample_out.csv
+++ b/sample_out.csv
@@ -1,0 +1,2 @@
+需求ID,测试点,HIL初始条件,HIL测试步骤,HIL预期结果
+D-SM-SWR2025061832,2.3.2.5.22 CDP激活,,AutomaticBrakingActive == 0x1: Active-CDP功能激活状态,DA_Inhibit = 5


### PR DESCRIPTION
Add normalization rules for signal and value annotations to correctly parse complex explanation formats like `{Signal}(Description) == Value(ValueDescription)`.

---
<a href="https://cursor.com/background-agent?bcId=bc-30f1ce53-a0d9-479c-aeb4-ae740148c186">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-30f1ce53-a0d9-479c-aeb4-ae740148c186">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

