### PR TITLE
Parse and normalize conditional logic

### DIFF
--- a/tmp_input3.txt
+++ b/tmp_input3.txt
@@ -6,3 +6,10 @@ IF
   3. 80<车速≤130  将夹角收紧为3°（TBD） 对应的横向速度1.16m/s~1.88m/s
 THEN
   {Lateral_ActivationPrevention} = 1
+
+2.3.2.5.4 车速高于抑制车速上限【D-SM-SWR2025061813】
+IF 
+  {Speed_Signal_151_S}> 135kph（国内ACC/ICC/HNOA）or {Speed_Signal_151_S}> 105kph（国内CNOA）
+  {Speed_Signal_151_S}> 155kph（海外）
+THEN
+  {DA_Inhibit} = 5

--- a/tmp_out3.csv
+++ b/tmp_out3.csv
@@ -1,2 +1,3 @@
 需求ID,测试点,HIL初始条件,HIL测试步骤,HIL预期结果
 D-SM-SWR2025061846,2.3.6.3 航向角超限,,0<车速≤40 维持当前夹角6°（TBD） 对应的横向速度 0~1.16m/s||40＜车速≤80 将夹角收紧为4°（TBD） 对应的横向速度0.7m/s~1.4m/s||80<车速≤130 将夹角收紧为3°（TBD） 对应的横向速度1.16m/s~1.88m/s,Lateral_ActivationPrevention = 1
+D-SM-SWR2025061813,2.3.2.5.4 车速高于抑制车速上限,,Speed_Signal_151_S> 135: kph: 国内ACC/ICC/HNOA || Speed_Signal_151_S> 105: kph: 国内CNOA && Speed_Signal_151_S> 155: kph: 海外,DA_Inhibit = 5


### PR DESCRIPTION
Improve condition parsing to correctly interpret slashes within parenthetical and colon-separated explanations.

This change prevents slashes in explanatory text (e.g., `（国内ACC/ICC/HNOA）` or after a colon like `0x0: Unavailable`) from being incorrectly treated as logical OR operators, ensuring that such annotations are preserved as part of the value's description.

---
<a href="https://cursor.com/background-agent?bcId=bc-145133f8-fa39-4f47-8995-c259c753717e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-145133f8-fa39-4f47-8995-c259c753717e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

