### PR TITLE
Add AGENTS.md with Cursor Cloud development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,39 @@
+## Cursor Cloud specific instructions
+
+### Project overview
+
+BEV+GPS to OpenDRIVE (XODR) Converter — a pure-Python CLI tool with **zero external dependencies**. See `README.md` for full details.
+
+### Running the application
+
+```bash
+python3 -m xodr_converter.cli \
+  --gps data/example/gps.csv \
+  --bev data/example/bev.json \
+  --out out/example.xodr
+```
+
+A second dataset is available at `data/verify400/`.
+
+### Linting
+
+```bash
+ruff check .                    # full repo (includes demo scripts)
+ruff check xodr_converter/     # main package only
+```
+
+Existing lint warnings in the main package (`F841` unused variables in `stitch.py` and `xodr.py`) are pre-existing in the repo.
+
+### Testing
+
+No automated tests exist yet. Use `pytest` to run any tests added in the future:
+
+```bash
+pytest -v
+```
+
+### Key caveats
+
+- `requirements.txt` is empty; the project relies entirely on the Python 3 standard library.
+- `ruff` and `pytest` are installed as dev tools via `pip install --user` and live in `~/.local/bin`. Make sure `PATH` includes `$HOME/.local/bin`.
+- Output directory (`out/`) is created automatically by the CLI if it does not exist.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Add `AGENTS.md` with Cursor Cloud specific development instructions for future cloud agents.

## Changes

- Created `AGENTS.md` with:
  - Project overview (pure Python CLI, zero external deps)
  - CLI run commands for both example datasets
  - Linting instructions using `ruff`
  - Testing instructions using `pytest`
  - Key caveats (empty `requirements.txt`, dev tool PATH, output directory behavior)

## Verification

Development environment was verified end-to-end:

- CLI runs successfully with both `data/example/` and `data/verify400/` datasets, producing valid OpenDRIVE XML
- All Python modules compile without errors
- `ruff` linting runs successfully (only pre-existing warnings)

[dev_env_verification.log](https://cursor.com/agents/bc-351ef908-c7ad-48a2-bfce-e270543400f7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdev_env_verification.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-351ef908-c7ad-48a2-bfce-e270543400f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-351ef908-c7ad-48a2-bfce-e270543400f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

