### PR TITLE
Add DBC to CANoe sysvar converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Convert one or more DBC files into a single CANoe `.vsysvar` XML file:
 python3 -m xodr_converter.dbc_to_vsysvar \
   --dbc ControlCAN=/path/to/control.dbc \
   --dbc ChassisCAN=/path/to/chassis.dbc \
+  --dbc-encoding gb18030 \
   --out /path/to/vehicle.vsysvar
 ```
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,11 @@ This project converts ego-centric BEV lane perception and GPS trajectory data in
 - At intersections, lane lines may be missing; the ego trajectory continues through the gap until lanes reappear.
 
 ## Install
-No external dependencies; uses Python 3 standard library.
+Install Python dependencies:
+
+```bash
+python3 -m pip install -r requirements.txt
+```
 
 ## Run
 ```bash

--- a/README.md
+++ b/README.md
@@ -24,6 +24,18 @@ python3 -m xodr_converter.cli \
 ## Outputs
 - An XODR file with a single road composed of lane sections, lane markings, zebra objects, and inferred traffic lights near stops.
 
+## DBC to CANoe system variables
+Convert one or more DBC files into a single CANoe `.vsysvar` XML file:
+
+```bash
+python3 -m xodr_converter.dbc_to_vsysvar \
+  --dbc ControlCAN=/path/to/control.dbc \
+  --dbc ChassisCAN=/path/to/chassis.dbc \
+  --out /path/to/vehicle.vsysvar
+```
+
+Each DBC becomes one namespace. Each DBC message becomes one struct definition plus one struct variable. Each signal creates `_Pv`, `_Rv`, `_Factor`, and `_Offset` struct members.
+
 ## Notes
 - Local ENU means: X axis points East, Y axis points North, Z axis Up, with origin at the first GPS fix. We use a local tangent-plane approximation suitable for short trips. Ego points (x forward, y left) are rotated by GPS heading (yaw clockwise from North) into this ENU frame.
 - Plan view (reference line) uses a parametric cubic polynomial (paramPoly3) fitted to the trajectory, with straight-line degenerate cubic when needed.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ python3 -m xodr_converter.dbc_to_vsysvar \
 ```
 
 Each DBC becomes one namespace. Each DBC message becomes one struct definition plus one struct variable. Each signal creates `_Pv`, `_Rv`, `_Factor`, and `_Offset` struct members.
+If comments look garbled, retry with a different `--dbc-encoding`, such as `gb18030`, `gbk`, or `cp936`.
 
 ## Notes
 - Local ENU means: X axis points East, Y axis points North, Z axis Up, with origin at the first GPS fix. We use a local tangent-plane approximation suitable for short trips. Ego points (x forward, y left) are rotated by GPS heading (yaw clockwise from North) into this ENU frame.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+cantools
 

--- a/test_dbc_to_vsysvar.py
+++ b/test_dbc_to_vsysvar.py
@@ -91,6 +91,20 @@ BA_ "GenMsgNrOfRepetition" BO_ 567 3;
 """
 
 
+WIDE_RAW_DBC = """
+VERSION ""
+
+NS_ :
+
+BS_:
+
+BU_: MAC ADC
+
+BO_ 459 MAC_0x1CB: 8 MAC
+ SG_ CutOutMAC_1CB_S : 0|48@1+ (1,0) [0|281474976710655] "" ADC
+"""
+
+
 class DbcToVsysvarTests(unittest.TestCase):
 	def test_builds_struct_members_and_message_variable(self) -> None:
 		database = parse_dbc_text(CONTROL_DBC)
@@ -278,6 +292,20 @@ class DbcToVsysvarTests(unittest.TestCase):
 		self.assertEqual("Cycle", send_type_entries["0"])
 		self.assertEqual("CE", send_type_entries["3"])
 		self.assertEqual("CA", send_type_entries["4"])
+
+	def test_omits_int_bounds_that_exceed_canoe_int_range(self) -> None:
+		database = parse_dbc_text(WIDE_RAW_DBC)
+		tree = build_vsysvar_tree([("ControlCAN", database)])
+		root = tree.getroot()
+		member = root.find(
+			"./namespace/namespace[@name='ControlCAN']/struct[@name='mac_0x1cb']"
+			"/structMember[@name='CutOutMAC_1CB_S_Rv']"
+		)
+
+		self.assertIsNotNone(member)
+		self.assertEqual("int", member.attrib["type"])
+		self.assertEqual("0", member.attrib["minValue"])
+		self.assertNotIn("maxValue", member.attrib)
 
 	def test_parses_cli_dbc_specs(self) -> None:
 		self.assertEqual(("ControlCAN", "control.dbc"), parse_dbc_spec("ControlCAN=control.dbc"))

--- a/test_dbc_to_vsysvar.py
+++ b/test_dbc_to_vsysvar.py
@@ -10,6 +10,7 @@ from xodr_converter.dbc_to_vsysvar import (
 	convert_dbc_files_to_vsysvar,
 	parse_dbc_text,
 	parse_dbc_spec,
+	decode_dbc_bytes,
 	read_text_file,
 )
 
@@ -157,6 +158,12 @@ class DbcToVsysvarTests(unittest.TestCase):
 			text = read_text_file(str(dbc_path), encoding="gb18030")
 
 			self.assertIn('CM_ SG_ 573 PAD_AVPPauseReq_S "用户暂停";', text)
+
+	def test_prefers_chinese_decoding_over_mojibake(self) -> None:
+		text = decode_dbc_bytes('CM_ SG_ 268 Checksum_10C_S "校验值_10C_S";'.encode("gbk"))
+
+		self.assertIn("校验值_10C_S", text)
+		self.assertNotIn("У���", text)
 
 	def test_parses_cli_dbc_specs(self) -> None:
 		self.assertEqual(("ControlCAN", "control.dbc"), parse_dbc_spec("ControlCAN=control.dbc"))

--- a/test_dbc_to_vsysvar.py
+++ b/test_dbc_to_vsysvar.py
@@ -185,12 +185,19 @@ class DbcToVsysvarTests(unittest.TestCase):
 		database = parse_dbc_text(ENUM_DBC)
 		tree = build_vsysvar_tree([("ControlCAN", database)])
 		root = tree.getroot()
+		pv_member = root.find(
+			"./namespace/namespace[@name='ControlCAN']/struct[@name='lda_0x237']"
+			"/structMember[@name='LDA_Func_Dis_Confm_Button_Pv']"
+		)
 		member = root.find(
 			"./namespace/namespace[@name='ControlCAN']/struct[@name='lda_0x237']"
 			"/structMember[@name='LDA_Func_Dis_Confm_Button_Rv']"
 		)
 
+		self.assertIsNotNone(pv_member)
+		self.assertEqual("int", pv_member.attrib["type"])
 		self.assertIsNotNone(member)
+		self.assertEqual("int", member.attrib["type"])
 		value_table = member.find("./valuetable[@name='LDA_Func_Dis_Confm_Button']")
 		self.assertIsNotNone(value_table)
 		entries = {entry.attrib["value"]: entry.attrib["displayString"] for entry in value_table.findall("valuetableentry")}

--- a/test_dbc_to_vsysvar.py
+++ b/test_dbc_to_vsysvar.py
@@ -140,8 +140,12 @@ class DbcToVsysvarTests(unittest.TestCase):
 		tree = build_vsysvar_tree([("ControlCAN", database)])
 		root = tree.getroot()
 		node_struct = root.find("./namespace/namespace[@name='ControlCAN']/struct[@name='controlcan_node_info']")
+		node_variable = root.find("./namespace/namespace[@name='ControlCAN']/variable[@name='ControlCAN_Node_Info']")
 
 		self.assertIsNotNone(node_struct)
+		self.assertIsNotNone(node_variable)
+		self.assertEqual("96", node_variable.attrib["bitcount"])
+		self.assertEqual("ControlCAN::controlcan_node_info", node_variable.attrib["structDefinition"])
 		members = {member.attrib["name"]: member.attrib for member in node_struct.findall("structMember")}
 		self.assertEqual({"Media_MsgOn", "ADC_MsgOn", "EPS_MsgOn"}, set(members))
 		for attrs in members.values():

--- a/test_dbc_to_vsysvar.py
+++ b/test_dbc_to_vsysvar.py
@@ -150,20 +150,19 @@ class DbcToVsysvarTests(unittest.TestCase):
 			self.assertIsNotNone(member)
 			self.assertEqual("用户暂停", member.attrib["comment"])
 
-	def test_falls_back_when_requested_encoding_does_not_match_file(self) -> None:
+	def test_requested_encoding_is_used_directly(self) -> None:
 		with tempfile.TemporaryDirectory() as temp_dir:
 			dbc_path = Path(temp_dir) / "control_utf8.dbc"
 			dbc_path.write_bytes(CONTROL_DBC.encode("utf-8"))
 
 			text = read_text_file(str(dbc_path), encoding="gb18030")
 
-			self.assertIn('CM_ SG_ 573 PAD_AVPPauseReq_S "用户暂停";', text)
+			self.assertIsInstance(text, str)
 
-	def test_prefers_chinese_decoding_over_mojibake(self) -> None:
+	def test_auto_detects_gbk_when_utf8_strict_decode_fails(self) -> None:
 		text = decode_dbc_bytes('CM_ SG_ 268 Checksum_10C_S "校验值_10C_S";'.encode("gbk"))
 
 		self.assertIn("校验值_10C_S", text)
-		self.assertNotIn("У���", text)
 
 	def test_parses_cli_dbc_specs(self) -> None:
 		self.assertEqual(("ControlCAN", "control.dbc"), parse_dbc_spec("ControlCAN=control.dbc"))

--- a/test_dbc_to_vsysvar.py
+++ b/test_dbc_to_vsysvar.py
@@ -58,6 +58,20 @@ BA_ "GenSigStartValue" SG_ 100 VehicleSpeed 1234;
 """
 
 
+INTEGER_PHYSICAL_DBC = """
+VERSION ""
+
+NS_ :
+
+BS_:
+
+BU_: BCM ADC
+
+BO_ 200 BodyStatus: 8 BCM
+ SG_ DoorStep : 0|8@1+ (2,0) [0|510] "" ADC
+"""
+
+
 ENUM_DBC = """
 VERSION ""
 
@@ -130,7 +144,7 @@ class DbcToVsysvarTests(unittest.TestCase):
 		self.assertEqual("Media", node_member["startValue"])
 
 		pause_pv = members["PAD_AVPPauseReq_S_Pv"]
-		self.assertEqual("double", pause_pv["type"])
+		self.assertEqual("int", pause_pv["type"])
 		self.assertEqual("false", pause_pv["isSigned"])
 		self.assertEqual("0", pause_pv["startValue"])
 		self.assertEqual("0", pause_pv["minValue"])
@@ -206,6 +220,20 @@ class DbcToVsysvarTests(unittest.TestCase):
 			self.assertIsNotNone(
 				root.find("./namespace/namespace[@name='ChassisCAN']/variable[@name='VehicleStatus']")
 			)
+
+	def test_uses_int_for_integral_physical_values_in_int_range(self) -> None:
+		database = parse_dbc_text(INTEGER_PHYSICAL_DBC)
+		tree = build_vsysvar_tree([("BodyCAN", database)])
+		root = tree.getroot()
+		member = root.find(
+			"./namespace/namespace[@name='BodyCAN']/struct[@name='bodystatus']"
+			"/structMember[@name='DoorStep_Pv']"
+		)
+
+		self.assertIsNotNone(member)
+		self.assertEqual("int", member.attrib["type"])
+		self.assertEqual("0", member.attrib["minValue"])
+		self.assertEqual("510", member.attrib["maxValue"])
 
 	def test_reads_gb18030_encoded_chinese_comments(self) -> None:
 		with tempfile.TemporaryDirectory() as temp_dir:
@@ -304,11 +332,17 @@ class DbcToVsysvarTests(unittest.TestCase):
 		database = parse_dbc_text(WIDE_RAW_DBC)
 		tree = build_vsysvar_tree([("ControlCAN", database)])
 		root = tree.getroot()
+		pv_member = root.find(
+			"./namespace/namespace[@name='ControlCAN']/struct[@name='mac_0x1cb']"
+			"/structMember[@name='CutOutMAC_1CB_S_Pv']"
+		)
 		member = root.find(
 			"./namespace/namespace[@name='ControlCAN']/struct[@name='mac_0x1cb']"
 			"/structMember[@name='CutOutMAC_1CB_S_Rv']"
 		)
 
+		self.assertIsNotNone(pv_member)
+		self.assertEqual("double", pv_member.attrib["type"])
 		self.assertIsNotNone(member)
 		self.assertEqual("int", member.attrib["type"])
 		self.assertEqual("0", member.attrib["minValue"])

--- a/test_dbc_to_vsysvar.py
+++ b/test_dbc_to_vsysvar.py
@@ -63,15 +63,25 @@ VERSION ""
 
 NS_ :
 	VAL_
+	BA_
+	BA_DEF_
+	BA_DEF_DEF_
 
 BS_:
 
 BU_: LDA ADC
 
+BA_DEF_ BO_ "GenMsgSendType" ENUM "Cycle", "Event", "IfActive", "CE" ,"CA", "NoMsgSendType";
+BA_DEF_DEF_ "GenMsgSendType" "Cycle";
+BA_DEF_ BO_ "GenMsgCycleTime" INT 0 65535;
+BA_DEF_DEF_ "GenMsgCycleTime" 10;
+
 BO_ 567 LDA_0x237: 8 LDA
  SG_ LDA_Func_Dis_Confm_Button : 0|2@1+ (1,0) [0|3] "" ADC
 
 VAL_ 567 LDA_Func_Dis_Confm_Button 0 "Invalid" 1 "Europe" 2 "Other" 3 "Reserved";
+BA_ "GenMsgSendType" BO_ 567 3;
+BA_ "GenMsgCycleTime" BO_ 567 20;
 """
 
 
@@ -198,7 +208,7 @@ class DbcToVsysvarTests(unittest.TestCase):
 		self.assertEqual("int", pv_member.attrib["type"])
 		self.assertIsNotNone(member)
 		self.assertEqual("int", member.attrib["type"])
-		value_table = member.find("./valuetable[@name='LDA_Func_Dis_Confm_Button']")
+		value_table = member.find("./valuetable[@name='LDA_Func_Dis_Confm_ButtonVt']")
 		self.assertIsNotNone(value_table)
 		entries = {entry.attrib["value"]: entry.attrib["displayString"] for entry in value_table.findall("valuetableentry")}
 		self.assertEqual(
@@ -210,6 +220,36 @@ class DbcToVsysvarTests(unittest.TestCase):
 			},
 			entries,
 		)
+
+	def test_writes_message_info_struct_from_message_attributes(self) -> None:
+		database = parse_dbc_text(ENUM_DBC)
+		tree = build_vsysvar_tree([("ControlCAN", database)])
+		root = tree.getroot()
+		info_struct = root.find("./namespace/namespace[@name='ControlCAN']/struct[@name='lda_0x237_info']")
+		info_variable = root.find("./namespace/namespace[@name='ControlCAN']/variable[@name='LDA_0x237_Info']")
+
+		self.assertIsNotNone(info_struct)
+		self.assertIsNotNone(info_variable)
+		self.assertEqual("128", info_variable.attrib["bitcount"])
+
+		members = {member.attrib["name"]: member for member in info_struct.findall("structMember")}
+		self.assertEqual("1", members["LDA_0x237_MsgOn"].attrib["startValue"])
+		self.assertEqual("0", members["LDA_0x237_MsgOff"].attrib["startValue"])
+		self.assertEqual("3", members["LDA_0x237_MsgSendType"].attrib["startValue"])
+		self.assertEqual("20", members["LDA_0x237_MsgCycleTime"].attrib["startValue"])
+		for member in members.values():
+			self.assertEqual("32", member.attrib["bitcount"])
+			self.assertEqual("int", member.attrib["type"])
+
+		value_table = members["LDA_0x237_MsgSendType"].find("./valuetable[@name='LDA_0x237_MsgSendTypeVt']")
+		self.assertIsNotNone(value_table)
+		send_type_entries = {
+			entry.attrib["value"]: entry.attrib["displayString"]
+			for entry in value_table.findall("valuetableentry")
+		}
+		self.assertEqual("Cycle", send_type_entries["0"])
+		self.assertEqual("CE", send_type_entries["3"])
+		self.assertEqual("CA", send_type_entries["4"])
 
 	def test_parses_cli_dbc_specs(self) -> None:
 		self.assertEqual(("ControlCAN", "control.dbc"), parse_dbc_spec("ControlCAN=control.dbc"))

--- a/test_dbc_to_vsysvar.py
+++ b/test_dbc_to_vsysvar.py
@@ -292,7 +292,7 @@ class DbcToVsysvarTests(unittest.TestCase):
 		self.assertIsNotNone(variable)
 		self.assertEqual("struct", variable.attrib["type"])
 		self.assertEqual("ControlCAN::media_0x23d", variable.attrib["structDefinition"])
-		self.assertEqual("1024", variable.attrib["bitcount"])
+		self.assertEqual("672", variable.attrib["bitcount"])
 
 	def test_writes_node_info_struct_from_bu_nodes(self) -> None:
 		database = parse_dbc_text(CONTROL_DBC)

--- a/test_dbc_to_vsysvar.py
+++ b/test_dbc_to_vsysvar.py
@@ -181,7 +181,7 @@ class DbcToVsysvarTests(unittest.TestCase):
 		self.assertEqual("False", struct.attrib["definedBinaryLayout"])
 
 		members = {member.attrib["name"]: member.attrib for member in struct.findall("structMember")}
-		self.assertEqual(9, len(members))
+		self.assertEqual(11, len(members))
 
 		node_member = members["Media_0x23D_node"]
 		self.assertEqual("string", node_member["type"])
@@ -217,11 +217,16 @@ class DbcToVsysvarTests(unittest.TestCase):
 		self.assertNotIn("minValue", angle_factor)
 		self.assertNotIn("maxValue", angle_factor)
 
+		pause_has_special = members["PAD_AVPPauseReq_S_has_special_value"]
+		self.assertEqual("int", pause_has_special["type"])
+		self.assertEqual("0", pause_has_special["startValue"])
+		self.assertNotIn("PAD_AVPPauseReq_S_special_value", members)
+
 		variable = namespace.find("./variable[@name='Media_0x23D']")
 		self.assertIsNotNone(variable)
 		self.assertEqual("struct", variable.attrib["type"])
 		self.assertEqual("ControlCAN::media_0x23d", variable.attrib["structDefinition"])
-		self.assertEqual("512", variable.attrib["bitcount"])
+		self.assertEqual("640", variable.attrib["bitcount"])
 
 	def test_writes_node_info_struct_from_bu_nodes(self) -> None:
 		database = parse_dbc_text(CONTROL_DBC)

--- a/test_dbc_to_vsysvar.py
+++ b/test_dbc_to_vsysvar.py
@@ -135,6 +135,22 @@ class DbcToVsysvarTests(unittest.TestCase):
 		self.assertEqual("ControlCAN::media_0x23d", variable.attrib["structDefinition"])
 		self.assertEqual("512", variable.attrib["bitcount"])
 
+	def test_writes_node_info_struct_from_bu_nodes(self) -> None:
+		database = parse_dbc_text(CONTROL_DBC)
+		tree = build_vsysvar_tree([("ControlCAN", database)])
+		root = tree.getroot()
+		node_struct = root.find("./namespace/namespace[@name='ControlCAN']/struct[@name='controlcan_node_info']")
+
+		self.assertIsNotNone(node_struct)
+		members = {member.attrib["name"]: member.attrib for member in node_struct.findall("structMember")}
+		self.assertEqual({"Media_MsgOn", "ADC_MsgOn", "EPS_MsgOn"}, set(members))
+		for attrs in members.values():
+			self.assertEqual("int", attrs["type"])
+			self.assertEqual("32", attrs["bitcount"])
+			self.assertEqual("1", attrs["startValue"])
+			self.assertEqual("0", attrs["minValue"])
+			self.assertEqual("1", attrs["maxValue"])
+
 	def test_writes_multiple_dbc_namespaces_to_one_file(self) -> None:
 		with tempfile.TemporaryDirectory() as temp_dir:
 			temp_path = Path(temp_dir)

--- a/test_dbc_to_vsysvar.py
+++ b/test_dbc_to_vsysvar.py
@@ -166,6 +166,26 @@ VAL_ 237 Mec_WhlSpd_FL_Pad 255 "Invalid";
 """
 
 
+INACTIVE_VALUE_DBC = """
+VERSION ""
+
+NS_ :
+	BA_
+	BA_DEF_
+
+BS_:
+
+BU_: BCM ADC
+
+BA_DEF_ SG_ "GenSigInactiveValue" INT 0 65535;
+
+BO_ 301 BCM_0x12D: 8 BCM
+ SG_ BCM_Mode : 0|8@1+ (1,0) [0|255] "" ADC
+
+BA_ "GenSigInactiveValue" SG_ 301 BCM_Mode 7;
+"""
+
+
 class DbcToVsysvarTests(unittest.TestCase):
 	def test_builds_struct_members_and_message_variable(self) -> None:
 		database = parse_dbc_text(CONTROL_DBC)
@@ -181,7 +201,7 @@ class DbcToVsysvarTests(unittest.TestCase):
 		self.assertEqual("False", struct.attrib["definedBinaryLayout"])
 
 		members = {member.attrib["name"]: member.attrib for member in struct.findall("structMember")}
-		self.assertEqual(11, len(members))
+		self.assertEqual(13, len(members))
 
 		node_member = members["Media_0x23D_node"]
 		self.assertEqual("string", node_member["type"])
@@ -221,12 +241,16 @@ class DbcToVsysvarTests(unittest.TestCase):
 		self.assertEqual("int", pause_has_special["type"])
 		self.assertEqual("0", pause_has_special["startValue"])
 		self.assertNotIn("PAD_AVPPauseReq_S_special_value", members)
+		pause_has_inactive = members["PAD_AVPPauseReq_S_has_inactive_value"]
+		self.assertEqual("int", pause_has_inactive["type"])
+		self.assertEqual("0", pause_has_inactive["startValue"])
+		self.assertNotIn("PAD_AVPPauseReq_S_inactive_value", members)
 
 		variable = namespace.find("./variable[@name='Media_0x23D']")
 		self.assertIsNotNone(variable)
 		self.assertEqual("struct", variable.attrib["type"])
 		self.assertEqual("ControlCAN::media_0x23d", variable.attrib["structDefinition"])
-		self.assertEqual("640", variable.attrib["bitcount"])
+		self.assertEqual("768", variable.attrib["bitcount"])
 
 	def test_writes_node_info_struct_from_bu_nodes(self) -> None:
 		database = parse_dbc_text(CONTROL_DBC)
@@ -421,6 +445,39 @@ class DbcToVsysvarTests(unittest.TestCase):
 			for entry in special_value.findall("./valuetable[@name='Mec_Vhl_Spd_special_valueVt']/valuetableentry")
 		}
 		self.assertEqual({"1023": "Invalid", "1024": "Error"}, special_entries)
+
+	def test_writes_inactive_value_members_from_signal_attribute(self) -> None:
+		database = parse_dbc_text(INACTIVE_VALUE_DBC)
+		tree = build_vsysvar_tree([("BodyCAN", database)])
+		root = tree.getroot()
+		struct = root.find("./namespace/namespace[@name='BodyCAN']/struct[@name='bcm_0x12d']")
+		self.assertIsNotNone(struct)
+
+		members = {member.attrib["name"]: member for member in struct.findall("structMember")}
+		has_inactive = members["BCM_Mode_has_inactive_value"]
+		use_inactive = members["BCM_Mode_use_inactive_value"]
+		inactive_value = members["BCM_Mode_inactive_value"]
+
+		self.assertEqual("1", has_inactive.attrib["startValue"])
+		has_entries = {
+			entry.attrib["value"]: entry.attrib["displayString"]
+			for entry in has_inactive.findall("./valuetable/valuetableentry")
+		}
+		self.assertEqual({"0": "no", "1": "yes"}, has_entries)
+
+		self.assertEqual("0", use_inactive.attrib["startValue"])
+		use_entries = {
+			entry.attrib["value"]: entry.attrib["displayString"]
+			for entry in use_inactive.findall("./valuetable/valuetableentry")
+		}
+		self.assertEqual({"0": "not use", "1": "use"}, use_entries)
+
+		self.assertEqual("7", inactive_value.attrib["startValue"])
+		inactive_entries = {
+			entry.attrib["value"]: entry.attrib["displayString"]
+			for entry in inactive_value.findall("./valuetable[@name='BCM_Mode_inactive_valueVt']/valuetableentry")
+		}
+		self.assertEqual({"7": "inactive"}, inactive_entries)
 
 	def test_writes_message_info_struct_from_message_attributes(self) -> None:
 		database = parse_dbc_text(ENUM_DBC)

--- a/test_dbc_to_vsysvar.py
+++ b/test_dbc_to_vsysvar.py
@@ -186,6 +186,21 @@ BA_ "GenSigInactiveValue" SG_ 301 BCM_Mode 7;
 """
 
 
+MULTIPLEXED_DBC = """
+VERSION ""
+
+NS_ :
+
+BS_:
+
+BU_: LMS VCP
+
+BO_ 500 LMS_0x1F4: 64 LMS
+ SG_ LMS_Mux M : 0|8@1+ (1,0) [0|255] "" VCP
+ SG_ LMS_Energy_Recovery_Quantity_Todata_S m64 : 152|20@1+ (0.1000000000000000055511151231257827021181583404541015625,0) [0E-008|99999.90000000] "KWh" VCP
+"""
+
+
 class DbcToVsysvarTests(unittest.TestCase):
 	def test_builds_struct_members_and_message_variable(self) -> None:
 		database = parse_dbc_text(CONTROL_DBC)
@@ -478,6 +493,20 @@ class DbcToVsysvarTests(unittest.TestCase):
 			for entry in inactive_value.findall("./valuetable[@name='BCM_Mode_inactive_valueVt']/valuetableentry")
 		}
 		self.assertEqual({"7": "inactive"}, inactive_entries)
+
+	def test_adds_multiplexer_id_suffix_to_signal_members(self) -> None:
+		database = parse_dbc_text(MULTIPLEXED_DBC)
+		tree = build_vsysvar_tree([("ControlCAN", database)])
+		root = tree.getroot()
+		struct = root.find("./namespace/namespace[@name='ControlCAN']/struct[@name='lms_0x1f4']")
+		self.assertIsNotNone(struct)
+
+		members = {member.attrib["name"]: member.attrib for member in struct.findall("structMember")}
+		self.assertIn("LMS_Energy_Recovery_Quantity_Todata_S_m64_Pv", members)
+		self.assertIn("LMS_Energy_Recovery_Quantity_Todata_S_m64_Rv", members)
+		self.assertIn("LMS_Energy_Recovery_Quantity_Todata_S_m64_has_special_value", members)
+		self.assertIn("LMS_Energy_Recovery_Quantity_Todata_S_m64_has_inactive_value", members)
+		self.assertNotIn("LMS_Energy_Recovery_Quantity_Todata_S_Pv", members)
 
 	def test_writes_message_info_struct_from_message_attributes(self) -> None:
 		database = parse_dbc_text(ENUM_DBC)

--- a/test_dbc_to_vsysvar.py
+++ b/test_dbc_to_vsysvar.py
@@ -405,6 +405,12 @@ class DbcToVsysvarTests(unittest.TestCase):
 
 		self.assertIn('CM_ SG_ 573 PAD_AVPPauseReq_S "用户暂停";', text)
 
+	def test_decode_replaces_invalid_bytes_for_requested_encoding(self) -> None:
+		text = decode_dbc_bytes(b'CM_ SG_ 1 Signal "\xbd";', preferred_encoding="gb18030")
+
+		self.assertIn("CM_ SG_ 1 Signal", text)
+		self.assertIn("\ufffd", text)
+
 	def test_writes_signal_value_table_from_val_definitions(self) -> None:
 		database = parse_dbc_text(ENUM_DBC)
 		tree = build_vsysvar_tree([("ControlCAN", database)])

--- a/test_dbc_to_vsysvar.py
+++ b/test_dbc_to_vsysvar.py
@@ -149,6 +149,15 @@ class DbcToVsysvarTests(unittest.TestCase):
 			self.assertIsNotNone(member)
 			self.assertEqual("用户暂停", member.attrib["comment"])
 
+	def test_falls_back_when_requested_encoding_does_not_match_file(self) -> None:
+		with tempfile.TemporaryDirectory() as temp_dir:
+			dbc_path = Path(temp_dir) / "control_utf8.dbc"
+			dbc_path.write_bytes(CONTROL_DBC.encode("utf-8"))
+
+			text = read_text_file(str(dbc_path), encoding="gb18030")
+
+			self.assertIn('CM_ SG_ 573 PAD_AVPPauseReq_S "用户暂停";', text)
+
 	def test_parses_cli_dbc_specs(self) -> None:
 		self.assertEqual(("ControlCAN", "control.dbc"), parse_dbc_spec("ControlCAN=control.dbc"))
 		namespace, path = parse_dbc_spec("/tmp/body-network.dbc")

--- a/test_dbc_to_vsysvar.py
+++ b/test_dbc_to_vsysvar.py
@@ -246,6 +246,7 @@ class DbcToVsysvarTests(unittest.TestCase):
 
 		pause_pv = members["PAD_AVPPauseReq_S_Pv"]
 		self.assertEqual("int", pause_pv["type"])
+		self.assertEqual("32", pause_pv["bitcount"])
 		self.assertEqual("false", pause_pv["isSigned"])
 		self.assertEqual("0", pause_pv["startValue"])
 		self.assertEqual("0", pause_pv["minValue"])
@@ -261,6 +262,7 @@ class DbcToVsysvarTests(unittest.TestCase):
 
 		angle_rv = members["EPS_SteerPinionAg_Rv"]
 		self.assertEqual("int", angle_rv["type"])
+		self.assertEqual("32", angle_rv["bitcount"])
 		self.assertEqual("2810", angle_rv["startValue"])
 		self.assertEqual("-7200", angle_rv["minValue"])
 		self.assertEqual("7200", angle_rv["maxValue"])

--- a/test_dbc_to_vsysvar.py
+++ b/test_dbc_to_vsysvar.py
@@ -75,6 +75,10 @@ BA_DEF_ BO_ "GenMsgSendType" ENUM "Cycle", "Event", "IfActive", "CE" ,"CA", "NoM
 BA_DEF_DEF_ "GenMsgSendType" "Cycle";
 BA_DEF_ BO_ "GenMsgCycleTime" INT 0 65535;
 BA_DEF_DEF_ "GenMsgCycleTime" 10;
+BA_DEF_ BO_ "GenMsgCycleTimeFast" INT 0 65535;
+BA_DEF_DEF_ "GenMsgCycleTimeFast" 0;
+BA_DEF_ BO_ "GenMsgNrOfRepetition" INT 0 255;
+BA_DEF_DEF_ "GenMsgNrOfRepetition" 0;
 
 BO_ 567 LDA_0x237: 8 LDA
  SG_ LDA_Func_Dis_Confm_Button : 0|2@1+ (1,0) [0|3] "" ADC
@@ -82,6 +86,8 @@ BO_ 567 LDA_0x237: 8 LDA
 VAL_ 567 LDA_Func_Dis_Confm_Button 0 "Invalid" 1 "Europe" 2 "Other" 3 "Reserved";
 BA_ "GenMsgSendType" BO_ 567 3;
 BA_ "GenMsgCycleTime" BO_ 567 20;
+BA_ "GenMsgCycleTimeFast" BO_ 567 5;
+BA_ "GenMsgNrOfRepetition" BO_ 567 3;
 """
 
 
@@ -250,13 +256,15 @@ class DbcToVsysvarTests(unittest.TestCase):
 
 		self.assertIsNotNone(info_struct)
 		self.assertIsNotNone(info_variable)
-		self.assertEqual("128", info_variable.attrib["bitcount"])
+		self.assertEqual("192", info_variable.attrib["bitcount"])
 
 		members = {member.attrib["name"]: member for member in info_struct.findall("structMember")}
 		self.assertEqual("1", members["LDA_0x237_MsgOn"].attrib["startValue"])
 		self.assertEqual("0", members["LDA_0x237_MsgOff"].attrib["startValue"])
 		self.assertEqual("3", members["LDA_0x237_MsgSendType"].attrib["startValue"])
 		self.assertEqual("20", members["LDA_0x237_MsgCycleTime"].attrib["startValue"])
+		self.assertEqual("5", members["LDA_0x237_MsgCycleTimeFast"].attrib["startValue"])
+		self.assertEqual("3", members["LDA_0x237_MsgNrOfRepetition"].attrib["startValue"])
 		for member in members.values():
 			self.assertEqual("32", member.attrib["bitcount"])
 			self.assertEqual("int", member.attrib["type"])

--- a/test_dbc_to_vsysvar.py
+++ b/test_dbc_to_vsysvar.py
@@ -152,17 +152,17 @@ class DbcToVsysvarTests(unittest.TestCase):
 
 	def test_requested_encoding_is_used_directly(self) -> None:
 		with tempfile.TemporaryDirectory() as temp_dir:
-			dbc_path = Path(temp_dir) / "control_utf8.dbc"
-			dbc_path.write_bytes(CONTROL_DBC.encode("utf-8"))
+			dbc_path = Path(temp_dir) / "control_gbk.dbc"
+			dbc_path.write_bytes(CONTROL_DBC.encode("gb18030"))
 
 			text = read_text_file(str(dbc_path), encoding="gb18030")
 
-			self.assertIsInstance(text, str)
+			self.assertIn('CM_ SG_ 573 PAD_AVPPauseReq_S "用户暂停";', text)
 
-	def test_auto_detects_gbk_when_utf8_strict_decode_fails(self) -> None:
-		text = decode_dbc_bytes('CM_ SG_ 268 Checksum_10C_S "校验值_10C_S";'.encode("gbk"))
+	def test_decode_uses_utf8_sig_by_default(self) -> None:
+		text = decode_dbc_bytes(CONTROL_DBC.encode("utf-8-sig"))
 
-		self.assertIn("校验值_10C_S", text)
+		self.assertIn('CM_ SG_ 573 PAD_AVPPauseReq_S "用户暂停";', text)
 
 	def test_parses_cli_dbc_specs(self) -> None:
 		self.assertEqual(("ControlCAN", "control.dbc"), parse_dbc_spec("ControlCAN=control.dbc"))

--- a/test_dbc_to_vsysvar.py
+++ b/test_dbc_to_vsysvar.py
@@ -235,7 +235,7 @@ class DbcToVsysvarTests(unittest.TestCase):
 		self.assertEqual("False", struct.attrib["definedBinaryLayout"])
 
 		members = {member.attrib["name"]: member.attrib for member in struct.findall("structMember")}
-		self.assertEqual(13, len(members))
+		self.assertEqual(17, len(members))
 
 		node_member = members["Media_0x23D_node"]
 		self.assertEqual("string", node_member["type"])
@@ -274,17 +274,23 @@ class DbcToVsysvarTests(unittest.TestCase):
 		pause_has_special = members["PAD_AVPPauseReq_S_has_special_value"]
 		self.assertEqual("int", pause_has_special["type"])
 		self.assertEqual("0", pause_has_special["startValue"])
+		pause_use_special = members["PAD_AVPPauseReq_S_use_special_value"]
+		self.assertEqual("int", pause_use_special["type"])
+		self.assertEqual("0", pause_use_special["startValue"])
 		self.assertNotIn("PAD_AVPPauseReq_S_special_value", members)
 		pause_has_inactive = members["PAD_AVPPauseReq_S_has_inactive_value"]
 		self.assertEqual("int", pause_has_inactive["type"])
 		self.assertEqual("0", pause_has_inactive["startValue"])
+		pause_use_inactive = members["PAD_AVPPauseReq_S_use_inactive_value"]
+		self.assertEqual("int", pause_use_inactive["type"])
+		self.assertEqual("0", pause_use_inactive["startValue"])
 		self.assertNotIn("PAD_AVPPauseReq_S_inactive_value", members)
 
 		variable = namespace.find("./variable[@name='Media_0x23D']")
 		self.assertIsNotNone(variable)
 		self.assertEqual("struct", variable.attrib["type"])
 		self.assertEqual("ControlCAN::media_0x23d", variable.attrib["structDefinition"])
-		self.assertEqual("768", variable.attrib["bitcount"])
+		self.assertEqual("1024", variable.attrib["bitcount"])
 
 	def test_writes_node_info_struct_from_bu_nodes(self) -> None:
 		database = parse_dbc_text(CONTROL_DBC)

--- a/test_dbc_to_vsysvar.py
+++ b/test_dbc_to_vsysvar.py
@@ -166,6 +166,40 @@ VAL_ 237 Mec_WhlSpd_FL_Pad 255 "Invalid";
 """
 
 
+NORMAL_VAL_NON_INT_PHYSICAL_DBC = """
+VERSION ""
+
+NS_ :
+	VAL_
+
+BS_:
+
+BU_: LMS VCP
+
+BO_ 1173 LMS_0x495: 64 LMS
+ SG_ LMS_Energy_Recovery_Quantity_Todata_S : 152|20@1+ (0.1,0) [0E-008|99999.90000000] "KWh" VCP
+
+VAL_ 1173 LMS_Energy_Recovery_Quantity_Todata_S 0 "Invalid" 1 "Close" 2 "On" 3 "Enable";
+"""
+
+
+PHYSICAL_VALUETABLE_DBC = """
+VERSION ""
+
+NS_ :
+	VAL_
+
+BS_:
+
+BU_: BCM ADC
+
+BO_ 302 BCM_0x12E: 8 BCM
+ SG_ StepMode : 0|2@1+ (2,0) [0|6] "" ADC
+
+VAL_ 302 StepMode 0 "Zero" 1 "Two" 2 "Four" 3 "Six";
+"""
+
+
 INACTIVE_VALUE_DBC = """
 VERSION ""
 
@@ -400,6 +434,67 @@ class DbcToVsysvarTests(unittest.TestCase):
 			},
 			entries,
 		)
+		pv_value_table = pv_member.find("./valuetable[@name='LDA_Func_Dis_Confm_ButtonVt']")
+		self.assertIsNotNone(pv_value_table)
+		pv_entries = {
+			entry.attrib["value"]: entry.attrib["displayString"]
+			for entry in pv_value_table.findall("valuetableentry")
+		}
+		self.assertEqual(entries, pv_entries)
+
+	def test_pv_omits_valuetable_when_physical_type_is_double(self) -> None:
+		database = parse_dbc_text(NORMAL_VAL_NON_INT_PHYSICAL_DBC)
+		tree = build_vsysvar_tree([("ControlCAN", database)])
+		root = tree.getroot()
+		pv_member = root.find(
+			"./namespace/namespace[@name='ControlCAN']/struct[@name='lms_0x495']"
+			"/structMember[@name='LMS_Energy_Recovery_Quantity_Todata_S_Pv']"
+		)
+		rv_member = root.find(
+			"./namespace/namespace[@name='ControlCAN']/struct[@name='lms_0x495']"
+			"/structMember[@name='LMS_Energy_Recovery_Quantity_Todata_S_Rv']"
+		)
+
+		self.assertIsNotNone(pv_member)
+		self.assertEqual("double", pv_member.attrib["type"])
+		self.assertEqual("99999.9", pv_member.attrib["maxValue"])
+		self.assertIsNone(pv_member.find("./valuetable"))
+		self.assertIsNotNone(rv_member)
+		rv_entries = {
+			entry.attrib["value"]: entry.attrib["displayString"]
+			for entry in rv_member.findall("./valuetable[@name='LMS_Energy_Recovery_Quantity_Todata_SVt']/valuetableentry")
+		}
+		self.assertEqual(
+			{"0": "Invalid", "1": "Close", "2": "On", "3": "Enable"},
+			rv_entries,
+		)
+
+	def test_pv_valuetable_values_are_physical_when_type_is_int(self) -> None:
+		database = parse_dbc_text(PHYSICAL_VALUETABLE_DBC)
+		tree = build_vsysvar_tree([("BodyCAN", database)])
+		root = tree.getroot()
+		pv_member = root.find(
+			"./namespace/namespace[@name='BodyCAN']/struct[@name='bcm_0x12e']"
+			"/structMember[@name='StepMode_Pv']"
+		)
+		rv_member = root.find(
+			"./namespace/namespace[@name='BodyCAN']/struct[@name='bcm_0x12e']"
+			"/structMember[@name='StepMode_Rv']"
+		)
+
+		self.assertIsNotNone(pv_member)
+		self.assertEqual("int", pv_member.attrib["type"])
+		pv_entries = {
+			entry.attrib["value"]: entry.attrib["displayString"]
+			for entry in pv_member.findall("./valuetable[@name='StepModeVt']/valuetableentry")
+		}
+		self.assertEqual({"0": "Zero", "2": "Two", "4": "Four", "6": "Six"}, pv_entries)
+		self.assertIsNotNone(rv_member)
+		rv_entries = {
+			entry.attrib["value"]: entry.attrib["displayString"]
+			for entry in rv_member.findall("./valuetable[@name='StepModeVt']/valuetableentry")
+		}
+		self.assertEqual({"0": "Zero", "1": "Two", "2": "Four", "3": "Six"}, rv_entries)
 
 	def test_writes_special_value_members_for_out_of_range_choices(self) -> None:
 		database = parse_dbc_text(SPECIAL_VALUE_DBC)

--- a/test_dbc_to_vsysvar.py
+++ b/test_dbc_to_vsysvar.py
@@ -120,7 +120,14 @@ class DbcToVsysvarTests(unittest.TestCase):
 		self.assertEqual("False", struct.attrib["definedBinaryLayout"])
 
 		members = {member.attrib["name"]: member.attrib for member in struct.findall("structMember")}
-		self.assertEqual(8, len(members))
+		self.assertEqual(9, len(members))
+
+		node_member = members["Media_0x23D_node"]
+		self.assertEqual("string", node_member["type"])
+		self.assertEqual("0", node_member["bitcount"])
+		self.assertEqual("false", node_member["isSigned"])
+		self.assertEqual("65001", node_member["encoding"])
+		self.assertEqual("Media", node_member["startValue"])
 
 		pause_pv = members["PAD_AVPPauseReq_S_Pv"]
 		self.assertEqual("double", pause_pv["type"])

--- a/test_dbc_to_vsysvar.py
+++ b/test_dbc_to_vsysvar.py
@@ -58,6 +58,23 @@ BA_ "GenSigStartValue" SG_ 100 VehicleSpeed 1234;
 """
 
 
+ENUM_DBC = """
+VERSION ""
+
+NS_ :
+	VAL_
+
+BS_:
+
+BU_: LDA ADC
+
+BO_ 567 LDA_0x237: 8 LDA
+ SG_ LDA_Func_Dis_Confm_Button : 0|2@1+ (1,0) [0|3] "" ADC
+
+VAL_ 567 LDA_Func_Dis_Confm_Button 0 "Invalid" 1 "Europe" 2 "Other" 3 "Reserved";
+"""
+
+
 class DbcToVsysvarTests(unittest.TestCase):
 	def test_builds_struct_members_and_message_variable(self) -> None:
 		database = parse_dbc_text(CONTROL_DBC)
@@ -163,6 +180,29 @@ class DbcToVsysvarTests(unittest.TestCase):
 		text = decode_dbc_bytes(CONTROL_DBC.encode("utf-8-sig"))
 
 		self.assertIn('CM_ SG_ 573 PAD_AVPPauseReq_S "用户暂停";', text)
+
+	def test_writes_signal_value_table_from_val_definitions(self) -> None:
+		database = parse_dbc_text(ENUM_DBC)
+		tree = build_vsysvar_tree([("ControlCAN", database)])
+		root = tree.getroot()
+		member = root.find(
+			"./namespace/namespace[@name='ControlCAN']/struct[@name='lda_0x237']"
+			"/structMember[@name='LDA_Func_Dis_Confm_Button_Rv']"
+		)
+
+		self.assertIsNotNone(member)
+		value_table = member.find("./valuetable[@name='LDA_Func_Dis_Confm_Button']")
+		self.assertIsNotNone(value_table)
+		entries = {entry.attrib["value"]: entry.attrib["displayString"] for entry in value_table.findall("valuetableentry")}
+		self.assertEqual(
+			{
+				"0": "Invalid",
+				"1": "Europe",
+				"2": "Other",
+				"3": "Reserved",
+			},
+			entries,
+		)
 
 	def test_parses_cli_dbc_specs(self) -> None:
 		self.assertEqual(("ControlCAN", "control.dbc"), parse_dbc_spec("ControlCAN=control.dbc"))

--- a/test_dbc_to_vsysvar.py
+++ b/test_dbc_to_vsysvar.py
@@ -388,13 +388,14 @@ class DbcToVsysvarTests(unittest.TestCase):
 		pv_member = members["Mec_Vhl_Spd_Pv"]
 		rv_member = members["Mec_Vhl_Spd_Rv"]
 		has_special = members["Mec_Vhl_Spd_has_special_value"]
+		use_special = members["Mec_Vhl_Spd_use_special_value"]
 		special_value = members["Mec_Vhl_Spd_special_value"]
 
 		self.assertEqual("double", pv_member.attrib["type"])
 		self.assertIsNone(pv_member.find("./valuetable"))
 		self.assertEqual("1022", rv_member.attrib["maxValue"])
 		self.assertIsNone(rv_member.find("./valuetable"))
-		self.assertEqual("0", has_special.attrib["startValue"])
+		self.assertEqual("1", has_special.attrib["startValue"])
 		self.assertEqual("0", has_special.attrib["minValue"])
 		self.assertEqual("1", has_special.attrib["maxValue"])
 		has_special_entries = {
@@ -402,6 +403,15 @@ class DbcToVsysvarTests(unittest.TestCase):
 			for entry in has_special.findall("./valuetable/valuetableentry")
 		}
 		self.assertEqual({"0": "no", "1": "yes"}, has_special_entries)
+
+		self.assertEqual("0", use_special.attrib["startValue"])
+		self.assertEqual("0", use_special.attrib["minValue"])
+		self.assertEqual("1", use_special.attrib["maxValue"])
+		use_special_entries = {
+			entry.attrib["value"]: entry.attrib["displayString"]
+			for entry in use_special.findall("./valuetable/valuetableentry")
+		}
+		self.assertEqual({"0": "not use", "1": "use"}, use_special_entries)
 
 		self.assertEqual("1023", special_value.attrib["startValue"])
 		self.assertNotIn("minValue", special_value.attrib)

--- a/test_dbc_to_vsysvar.py
+++ b/test_dbc_to_vsysvar.py
@@ -86,6 +86,20 @@ BO_ 201 ACC_0x0C9: 8 ACC
 """
 
 
+INVALID_RAW_RANGE_DBC = """
+VERSION ""
+
+NS_ :
+
+BS_:
+
+BU_: VCU VCP
+
+BO_ 300 VCU_0x12C: 8 VCU
+ SG_ VCU_AX : 16|12@1+ (0.0096153846153846193878234061003240640275180339813232421875,-19.69230769230770050626233569346368312835693359375) [-19.69230769|-19.69230769] "" VCP
+"""
+
+
 ENUM_DBC = """
 VERSION ""
 
@@ -262,6 +276,21 @@ class DbcToVsysvarTests(unittest.TestCase):
 		self.assertEqual("double", member.attrib["type"])
 		self.assertEqual("0", member.attrib["minValue"])
 		self.assertEqual("255.5", member.attrib["maxValue"])
+
+	def test_omits_rv_bounds_when_physical_range_cannot_map_to_raw_integer(self) -> None:
+		database = parse_dbc_text(INVALID_RAW_RANGE_DBC)
+		tree = build_vsysvar_tree([("ControlCAN", database)])
+		root = tree.getroot()
+		member = root.find(
+			"./namespace/namespace[@name='ControlCAN']/struct[@name='vcu_0x12c']"
+			"/structMember[@name='VCU_AX_Rv']"
+		)
+
+		self.assertIsNotNone(member)
+		self.assertEqual("int", member.attrib["type"])
+		self.assertEqual("0", member.attrib["startValue"])
+		self.assertNotIn("minValue", member.attrib)
+		self.assertNotIn("maxValue", member.attrib)
 
 	def test_reads_gb18030_encoded_chinese_comments(self) -> None:
 		with tempfile.TemporaryDirectory() as temp_dir:

--- a/test_dbc_to_vsysvar.py
+++ b/test_dbc_to_vsysvar.py
@@ -19,6 +19,7 @@ VERSION ""
 NS_ :
 	CM_
 	BA_
+	BA_DEF_
 
 BS_:
 
@@ -28,6 +29,7 @@ BO_ 573 Media_0x23D: 8 Media
  SG_ PAD_AVPPauseReq_S : 0|1@1+ (1,0) [0|1] ""  ADC
  SG_ EPS_SteerPinionAg : 44|16@1- (0.1,0) [-720|720] "deg"  ADC
 
+BA_DEF_ SG_ "GenSigStartValue" FLOAT 0 100000000000;
 CM_ SG_ 573 PAD_AVPPauseReq_S "用户暂停";
 CM_ SG_ 573 EPS_SteerPinionAg "转向小齿轮角度";
 BA_ "GenSigStartValue" SG_ 573 PAD_AVPPauseReq_S 0;
@@ -40,6 +42,7 @@ VERSION ""
 
 NS_ :
 	BA_
+	BA_DEF_
 
 BS_:
 
@@ -48,6 +51,7 @@ BU_: ABS ADC
 BO_ 100 VehicleStatus: 8 ABS
  SG_ VehicleSpeed : 0|16@1+ (0.01,0) [0|250] "km/h"  ADC
 
+BA_DEF_ SG_ "GenSigStartValue" FLOAT 0 100000000000;
 BA_ "GenSigStartValue" SG_ 100 VehicleSpeed 1234;
 """
 

--- a/test_dbc_to_vsysvar.py
+++ b/test_dbc_to_vsysvar.py
@@ -186,21 +186,6 @@ BA_ "GenSigInactiveValue" SG_ 301 BCM_Mode 7;
 """
 
 
-MULTIPLEXED_DBC = """
-VERSION ""
-
-NS_ :
-
-BS_:
-
-BU_: LMS VCP
-
-BO_ 500 LMS_0x1F4: 64 LMS
- SG_ LMS_Mux M : 0|8@1+ (1,0) [0|255] "" VCP
- SG_ LMS_Energy_Recovery_Quantity_Todata_S m64 : 152|20@1+ (0.1000000000000000055511151231257827021181583404541015625,0) [0E-008|99999.90000000] "KWh" VCP
-"""
-
-
 class DbcToVsysvarTests(unittest.TestCase):
 	def test_builds_struct_members_and_message_variable(self) -> None:
 		database = parse_dbc_text(CONTROL_DBC)
@@ -493,20 +478,6 @@ class DbcToVsysvarTests(unittest.TestCase):
 			for entry in inactive_value.findall("./valuetable[@name='BCM_Mode_inactive_valueVt']/valuetableentry")
 		}
 		self.assertEqual({"7": "inactive"}, inactive_entries)
-
-	def test_adds_multiplexer_id_suffix_to_signal_members(self) -> None:
-		database = parse_dbc_text(MULTIPLEXED_DBC)
-		tree = build_vsysvar_tree([("ControlCAN", database)])
-		root = tree.getroot()
-		struct = root.find("./namespace/namespace[@name='ControlCAN']/struct[@name='lms_0x1f4']")
-		self.assertIsNotNone(struct)
-
-		members = {member.attrib["name"]: member.attrib for member in struct.findall("structMember")}
-		self.assertIn("LMS_Energy_Recovery_Quantity_Todata_S_m64_Pv", members)
-		self.assertIn("LMS_Energy_Recovery_Quantity_Todata_S_m64_Rv", members)
-		self.assertIn("LMS_Energy_Recovery_Quantity_Todata_S_m64_has_special_value", members)
-		self.assertIn("LMS_Energy_Recovery_Quantity_Todata_S_m64_has_inactive_value", members)
-		self.assertNotIn("LMS_Energy_Recovery_Quantity_Todata_S_Pv", members)
 
 	def test_writes_message_info_struct_from_message_attributes(self) -> None:
 		database = parse_dbc_text(ENUM_DBC)

--- a/test_dbc_to_vsysvar.py
+++ b/test_dbc_to_vsysvar.py
@@ -147,6 +147,25 @@ BO_ 459 MAC_0x1CB: 8 MAC
 """
 
 
+SPECIAL_VALUE_DBC = """
+VERSION ""
+
+NS_ :
+	VAL_
+
+BS_:
+
+BU_: MEC VCP
+
+BO_ 237 MEC_0x0ED: 8 MEC
+ SG_ Mec_Vhl_Spd : 0|12@1+ (0.1,0) [0E-008|102.20000000] "" VCP
+ SG_ Mec_WhlSpd_FL_Pad : 16|8@1+ (1,0) [0E-008|254.00000000] "" VCP
+
+VAL_ 237 Mec_Vhl_Spd 1023 "Invalid" 1024 "Error";
+VAL_ 237 Mec_WhlSpd_FL_Pad 255 "Invalid";
+"""
+
+
 class DbcToVsysvarTests(unittest.TestCase):
 	def test_builds_struct_members_and_message_variable(self) -> None:
 		database = parse_dbc_text(CONTROL_DBC)
@@ -352,6 +371,41 @@ class DbcToVsysvarTests(unittest.TestCase):
 			},
 			entries,
 		)
+
+	def test_writes_special_value_members_for_out_of_range_choices(self) -> None:
+		database = parse_dbc_text(SPECIAL_VALUE_DBC)
+		tree = build_vsysvar_tree([("ControlCAN", database)])
+		root = tree.getroot()
+		struct = root.find("./namespace/namespace[@name='ControlCAN']/struct[@name='mec_0x0ed']")
+		self.assertIsNotNone(struct)
+
+		members = {member.attrib["name"]: member for member in struct.findall("structMember")}
+		pv_member = members["Mec_Vhl_Spd_Pv"]
+		rv_member = members["Mec_Vhl_Spd_Rv"]
+		has_special = members["Mec_Vhl_Spd_has_special_value"]
+		special_value = members["Mec_Vhl_Spd_special_value"]
+
+		self.assertEqual("double", pv_member.attrib["type"])
+		self.assertIsNone(pv_member.find("./valuetable"))
+		self.assertEqual("1022", rv_member.attrib["maxValue"])
+		self.assertIsNone(rv_member.find("./valuetable"))
+		self.assertEqual("0", has_special.attrib["startValue"])
+		self.assertEqual("0", has_special.attrib["minValue"])
+		self.assertEqual("1", has_special.attrib["maxValue"])
+		has_special_entries = {
+			entry.attrib["value"]: entry.attrib["displayString"]
+			for entry in has_special.findall("./valuetable/valuetableentry")
+		}
+		self.assertEqual({"0": "no", "1": "yes"}, has_special_entries)
+
+		self.assertEqual("1023", special_value.attrib["startValue"])
+		self.assertNotIn("minValue", special_value.attrib)
+		self.assertNotIn("maxValue", special_value.attrib)
+		special_entries = {
+			entry.attrib["value"]: entry.attrib["displayString"]
+			for entry in special_value.findall("./valuetable[@name='Mec_Vhl_Spd_special_valueVt']/valuetableentry")
+		}
+		self.assertEqual({"1023": "Invalid", "1024": "Error"}, special_entries)
 
 	def test_writes_message_info_struct_from_message_attributes(self) -> None:
 		database = parse_dbc_text(ENUM_DBC)

--- a/test_dbc_to_vsysvar.py
+++ b/test_dbc_to_vsysvar.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from xml.etree import ElementTree as ET
+
+from xodr_converter.dbc_to_vsysvar import (
+	build_vsysvar_tree,
+	convert_dbc_files_to_vsysvar,
+	parse_dbc_text,
+	parse_dbc_spec,
+)
+
+
+CONTROL_DBC = """
+VERSION ""
+
+NS_ :
+	CM_
+	BA_
+
+BS_:
+
+BU_: Media ADC EPS
+
+BO_ 573 Media_0x23D: 8 Media
+ SG_ PAD_AVPPauseReq_S : 0|1@1+ (1,0) [0|1] ""  ADC
+ SG_ EPS_SteerPinionAg : 44|16@1- (0.1,0) [-720|720] "deg"  ADC
+
+CM_ SG_ 573 PAD_AVPPauseReq_S "用户暂停";
+CM_ SG_ 573 EPS_SteerPinionAg "转向小齿轮角度";
+BA_ "GenSigStartValue" SG_ 573 PAD_AVPPauseReq_S 0;
+BA_ "GenSigStartValue" SG_ 573 EPS_SteerPinionAg 2810;
+"""
+
+
+CHASSIS_DBC = """
+VERSION ""
+
+NS_ :
+	BA_
+
+BS_:
+
+BU_: ABS ADC
+
+BO_ 100 VehicleStatus: 8 ABS
+ SG_ VehicleSpeed : 0|16@1+ (0.01,0) [0|250] "km/h"  ADC
+
+BA_ "GenSigStartValue" SG_ 100 VehicleSpeed 1234;
+"""
+
+
+class DbcToVsysvarTests(unittest.TestCase):
+	def test_builds_struct_members_and_message_variable(self) -> None:
+		database = parse_dbc_text(CONTROL_DBC)
+		tree = build_vsysvar_tree([("ControlCAN", database)])
+		root = tree.getroot()
+
+		namespace = root.find("./namespace/namespace[@name='ControlCAN']")
+		self.assertIsNotNone(namespace)
+
+		struct = namespace.find("./struct[@name='media_0x23d']")
+		self.assertIsNotNone(struct)
+		self.assertEqual("False", struct.attrib["isUnion"])
+		self.assertEqual("False", struct.attrib["definedBinaryLayout"])
+
+		members = {member.attrib["name"]: member.attrib for member in struct.findall("structMember")}
+		self.assertEqual(8, len(members))
+
+		pause_pv = members["PAD_AVPPauseReq_S_Pv"]
+		self.assertEqual("double", pause_pv["type"])
+		self.assertEqual("false", pause_pv["isSigned"])
+		self.assertEqual("0", pause_pv["startValue"])
+		self.assertEqual("0", pause_pv["minValue"])
+		self.assertEqual("1", pause_pv["maxValue"])
+		self.assertEqual("用户暂停", pause_pv["comment"])
+
+		angle_pv = members["EPS_SteerPinionAg_Pv"]
+		self.assertEqual("double", angle_pv["type"])
+		self.assertEqual("true", angle_pv["isSigned"])
+		self.assertEqual("281", angle_pv["startValue"])
+		self.assertEqual("-720", angle_pv["minValue"])
+		self.assertEqual("720", angle_pv["maxValue"])
+
+		angle_rv = members["EPS_SteerPinionAg_Rv"]
+		self.assertEqual("int", angle_rv["type"])
+		self.assertEqual("2810", angle_rv["startValue"])
+		self.assertEqual("-7200", angle_rv["minValue"])
+		self.assertEqual("7200", angle_rv["maxValue"])
+
+		angle_factor = members["EPS_SteerPinionAg_Factor"]
+		self.assertEqual("double", angle_factor["type"])
+		self.assertEqual("0.1", angle_factor["startValue"])
+		self.assertNotIn("minValue", angle_factor)
+		self.assertNotIn("maxValue", angle_factor)
+
+		variable = namespace.find("./variable[@name='Media_0x23D']")
+		self.assertIsNotNone(variable)
+		self.assertEqual("struct", variable.attrib["type"])
+		self.assertEqual("ControlCAN::media_0x23d", variable.attrib["structDefinition"])
+		self.assertEqual("512", variable.attrib["bitcount"])
+
+	def test_writes_multiple_dbc_namespaces_to_one_file(self) -> None:
+		with tempfile.TemporaryDirectory() as temp_dir:
+			temp_path = Path(temp_dir)
+			control_path = temp_path / "control.dbc"
+			chassis_path = temp_path / "chassis.dbc"
+			output_path = temp_path / "vehicle.vsysvar"
+			control_path.write_text(CONTROL_DBC, encoding="utf-8")
+			chassis_path.write_text(CHASSIS_DBC, encoding="utf-8")
+
+			convert_dbc_files_to_vsysvar(
+				[
+					("ControlCAN", str(control_path)),
+					("ChassisCAN", str(chassis_path)),
+				],
+				str(output_path),
+			)
+
+			root = ET.parse(output_path).getroot()
+			self.assertEqual("4", root.attrib["version"])
+			self.assertIsNotNone(root.find("./namespace/namespace[@name='ControlCAN']"))
+			self.assertIsNotNone(root.find("./namespace/namespace[@name='ChassisCAN']"))
+			self.assertIsNotNone(
+				root.find("./namespace/namespace[@name='ChassisCAN']/variable[@name='VehicleStatus']")
+			)
+
+	def test_parses_cli_dbc_specs(self) -> None:
+		self.assertEqual(("ControlCAN", "control.dbc"), parse_dbc_spec("ControlCAN=control.dbc"))
+		namespace, path = parse_dbc_spec("/tmp/body-network.dbc")
+		self.assertEqual("body_network", namespace)
+		self.assertEqual("/tmp/body-network.dbc", path)
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/test_dbc_to_vsysvar.py
+++ b/test_dbc_to_vsysvar.py
@@ -72,6 +72,20 @@ BO_ 200 BodyStatus: 8 BCM
 """
 
 
+FRACTIONAL_BOUND_DBC = """
+VERSION ""
+
+NS_ :
+
+BS_:
+
+BU_: ACC ADC
+
+BO_ 201 ACC_0x0C9: 8 ACC
+ SG_ Set_Speed_S : 0|9@1+ (1,0) [0E-008|255.50000000] "" ADC
+"""
+
+
 ENUM_DBC = """
 VERSION ""
 
@@ -234,6 +248,20 @@ class DbcToVsysvarTests(unittest.TestCase):
 		self.assertEqual("int", member.attrib["type"])
 		self.assertEqual("0", member.attrib["minValue"])
 		self.assertEqual("510", member.attrib["maxValue"])
+
+	def test_uses_double_when_physical_bounds_are_fractional(self) -> None:
+		database = parse_dbc_text(FRACTIONAL_BOUND_DBC)
+		tree = build_vsysvar_tree([("ControlCAN", database)])
+		root = tree.getroot()
+		member = root.find(
+			"./namespace/namespace[@name='ControlCAN']/struct[@name='acc_0x0c9']"
+			"/structMember[@name='Set_Speed_S_Pv']"
+		)
+
+		self.assertIsNotNone(member)
+		self.assertEqual("double", member.attrib["type"])
+		self.assertEqual("0", member.attrib["minValue"])
+		self.assertEqual("255.5", member.attrib["maxValue"])
 
 	def test_reads_gb18030_encoded_chinese_comments(self) -> None:
 		with tempfile.TemporaryDirectory() as temp_dir:

--- a/test_dbc_to_vsysvar.py
+++ b/test_dbc_to_vsysvar.py
@@ -10,6 +10,7 @@ from xodr_converter.dbc_to_vsysvar import (
 	convert_dbc_files_to_vsysvar,
 	parse_dbc_text,
 	parse_dbc_spec,
+	read_text_file,
 )
 
 
@@ -130,6 +131,23 @@ class DbcToVsysvarTests(unittest.TestCase):
 			self.assertIsNotNone(
 				root.find("./namespace/namespace[@name='ChassisCAN']/variable[@name='VehicleStatus']")
 			)
+
+	def test_reads_gb18030_encoded_chinese_comments(self) -> None:
+		with tempfile.TemporaryDirectory() as temp_dir:
+			dbc_path = Path(temp_dir) / "control_gbk.dbc"
+			dbc_path.write_bytes(CONTROL_DBC.encode("gb18030"))
+
+			text = read_text_file(str(dbc_path), encoding="gb18030")
+			database = parse_dbc_text(text)
+			tree = build_vsysvar_tree([("ControlCAN", database)])
+			root = tree.getroot()
+			member = root.find(
+				"./namespace/namespace[@name='ControlCAN']/struct[@name='media_0x23d']"
+				"/structMember[@name='PAD_AVPPauseReq_S_Pv']"
+			)
+
+			self.assertIsNotNone(member)
+			self.assertEqual("用户暂停", member.attrib["comment"])
 
 	def test_parses_cli_dbc_specs(self) -> None:
 		self.assertEqual(("ControlCAN", "control.dbc"), parse_dbc_spec("ControlCAN=control.dbc"))

--- a/test_xvp_generator.py
+++ b/test_xvp_generator.py
@@ -113,7 +113,7 @@ class XvpGeneratorTests(unittest.TestCase):
 			)
 			raw_combo_size = raw_combo_box.find("./Property[@Name='Size']")
 			self.assertIsNotNone(raw_combo_size)
-			self.assertEqual("120, 23", raw_combo_size.text)
+			self.assertEqual("140, 23", raw_combo_size.text)
 
 			physical_text_box = next(
 				obj
@@ -168,7 +168,7 @@ class XvpGeneratorTests(unittest.TestCase):
 			)
 			numeric_raw_size = numeric_raw_text_box.find("./Property[@Name='Size']")
 			self.assertIsNotNone(numeric_raw_size)
-			self.assertEqual("120, 25", numeric_raw_size.text)
+			self.assertEqual("140, 25", numeric_raw_size.text)
 
 
 if __name__ == "__main__":

--- a/test_xvp_generator.py
+++ b/test_xvp_generator.py
@@ -99,6 +99,19 @@ class XvpGeneratorTests(unittest.TestCase):
 				symbol_configurations,
 			)
 
+			physical_text_box = next(
+				obj
+				for obj in root.findall(".//Object")
+				if any(
+					prop.get("Name") == "SymbolConfiguration"
+					and prop.text == "8;128;control;;IPB_0x10C;VehicleSpeed_Pv;2;;;-1;;;Value;;;0"
+					for prop in obj.findall("./Property")
+				)
+			)
+			alarm_settings = physical_text_box.find("./Property[@Name='AlarmGeneralSettings']")
+			self.assertIsNotNone(alarm_settings)
+			self.assertEqual("1;102.2;0;3", alarm_settings.text)
+
 
 if __name__ == "__main__":
 	unittest.main()

--- a/test_xvp_generator.py
+++ b/test_xvp_generator.py
@@ -111,6 +111,22 @@ class XvpGeneratorTests(unittest.TestCase):
 			alarm_settings = physical_text_box.find("./Property[@Name='AlarmGeneralSettings']")
 			self.assertIsNotNone(alarm_settings)
 			self.assertEqual("1;102.2;0;3", alarm_settings.text)
+			physical_value_display = physical_text_box.find("./Property[@Name='ValueDisplay']")
+			self.assertIsNotNone(physical_value_display)
+			self.assertEqual("Double", physical_value_display.text)
+
+			int_text_box = next(
+				obj
+				for obj in root.findall(".//Object")
+				if any(
+					prop.get("Name") == "SymbolConfiguration"
+					and prop.text == "8;128;control;;IPB_0x10C;NoRange_Rv;2;;;-1;;;Value;;;0"
+					for prop in obj.findall("./Property")
+				)
+			)
+			int_value_display = int_text_box.find("./Property[@Name='ValueDisplay']")
+			self.assertIsNotNone(int_value_display)
+			self.assertEqual("Decimal", int_value_display.text)
 
 			no_range_text_box = next(
 				obj

--- a/test_xvp_generator.py
+++ b/test_xvp_generator.py
@@ -24,6 +24,8 @@ SYSVAR_XML = """<?xml version="1.0" encoding="utf-8"?>
         <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="VehicleSpeed_use_inactive_value" comment="" bitcount="64" isSigned="false" encoding="65001" type="int" startValue="0" minValue="0" maxValue="1" />
         <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="NoRange_Rv" comment="" bitcount="64" isSigned="false" encoding="65001" type="int" startValue="0" />
         <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="NoRange_Pv" comment="" bitcount="64" isSigned="false" encoding="65001" type="double" startValue="0" />
+        <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="NumericRaw_Rv" comment="" bitcount="64" isSigned="false" encoding="65001" type="int" startValue="0" minValue="0" maxValue="4095" />
+        <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="NumericRaw_Pv" comment="" bitcount="64" isSigned="false" encoding="65001" type="double" startValue="0" minValue="0" maxValue="409.5" />
       </struct>
       <struct name="eps_0x06d" isUnion="False" definedBinaryLayout="False" comment="">
         <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="SteerAngle_Rv" comment="" bitcount="64" isSigned="true" encoding="65001" type="int" startValue="0" minValue="-7200" maxValue="7200" />
@@ -69,6 +71,7 @@ class XvpGeneratorTests(unittest.TestCase):
 			self.assertIn("VehicleSpeed", group_texts)
 			self.assertIn("min: 0", group_texts)
 			self.assertIn("max: 102.2", group_texts)
+			self.assertIn("max: 4095", group_texts)
 			self.assertIn("min: ~", group_texts)
 			self.assertIn("max: ~", group_texts)
 			min_text = next(
@@ -140,6 +143,19 @@ class XvpGeneratorTests(unittest.TestCase):
 			no_range_alarm_settings = no_range_text_box.find("./Property[@Name='AlarmGeneralSettings']")
 			self.assertIsNotNone(no_range_alarm_settings)
 			self.assertEqual("1;3;-2147483648;2147483647", no_range_alarm_settings.text)
+
+			numeric_raw_text_box = next(
+				obj
+				for obj in root.findall(".//Object")
+				if any(
+					prop.get("Name") == "SymbolConfiguration"
+					and prop.text == "8;128;control;;IPB_0x10C;NumericRaw_Rv;2;;;-1;;;Value;;;0"
+					for prop in obj.findall("./Property")
+				)
+			)
+			numeric_raw_size = numeric_raw_text_box.find("./Property[@Name='Size']")
+			self.assertIsNotNone(numeric_raw_size)
+			self.assertEqual("120, 25", numeric_raw_size.text)
 
 
 if __name__ == "__main__":

--- a/test_xvp_generator.py
+++ b/test_xvp_generator.py
@@ -67,8 +67,10 @@ class XvpGeneratorTests(unittest.TestCase):
 			]
 			self.assertIn("Message Name: IPB_0x10C", group_texts)
 			self.assertIn("VehicleSpeed", group_texts)
-			self.assertIn("min: 0    max: 102.2", group_texts)
-			self.assertIn("min: ~    max: ~", group_texts)
+			self.assertIn("min: 0", group_texts)
+			self.assertIn("max: 102.2", group_texts)
+			self.assertIn("min: ~", group_texts)
+			self.assertIn("max: ~", group_texts)
 
 			object_types = [obj.get("Type", "") for obj in root.findall(".//Object")]
 			self.assertTrue(any("ComboBoxControl" in obj_type for obj_type in object_types))

--- a/test_xvp_generator.py
+++ b/test_xvp_generator.py
@@ -23,7 +23,14 @@ SYSVAR_XML = """<?xml version="1.0" encoding="utf-8"?>
         <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="VehicleSpeed_use_special_value" comment="" bitcount="64" isSigned="false" encoding="65001" type="int" startValue="0" minValue="0" maxValue="1" />
         <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="VehicleSpeed_use_inactive_value" comment="" bitcount="64" isSigned="false" encoding="65001" type="int" startValue="0" minValue="0" maxValue="1" />
       </struct>
+      <struct name="eps_0x06d" isUnion="False" definedBinaryLayout="False" comment="">
+        <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="SteerAngle_Rv" comment="" bitcount="64" isSigned="true" encoding="65001" type="int" startValue="0" minValue="-7200" maxValue="7200" />
+        <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="SteerAngle_Pv" comment="" bitcount="64" isSigned="true" encoding="65001" type="double" startValue="0" minValue="-720" maxValue="720" />
+        <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="SteerAngle_use_special_value" comment="" bitcount="64" isSigned="false" encoding="65001" type="int" startValue="0" minValue="0" maxValue="1" />
+        <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="SteerAngle_use_inactive_value" comment="" bitcount="64" isSigned="false" encoding="65001" type="int" startValue="0" minValue="0" maxValue="1" />
+      </struct>
       <variable anlyzLocal="2" readOnly="false" valueSequence="false" unit="" name="IPB_0x10C" comment="" bitcount="256" isSigned="true" encoding="65001" type="struct" structDefinition="control::ipb_0x10c" />
+      <variable anlyzLocal="2" readOnly="false" valueSequence="false" unit="" name="EPS_0x06D" comment="" bitcount="256" isSigned="true" encoding="65001" type="struct" structDefinition="control::eps_0x06d" />
       <variable anlyzLocal="2" readOnly="false" valueSequence="false" unit="" name="IPB_0x10C_Info" comment="" bitcount="128" isSigned="true" encoding="65001" type="struct" structDefinition="control::ipb_0x10c_info" />
     </namespace>
   </namespace>
@@ -37,12 +44,16 @@ class XvpGeneratorTests(unittest.TestCase):
 			sysvar_path = Path(temp_dir) / "demo.vsysvar"
 			sysvar_path.write_text(SYSVAR_XML, encoding="utf-8")
 
-			output_path = generation_xvp(
+			output_paths = generation_xvp(
 				str(sysvar_path),
-				{"control": ["IPB_0x10C"]},
+				{"control": ["IPB_0x10C", "EPS_0x06D"]},
 				temp_dir,
 			)
 
+			self.assertEqual(2, len(output_paths))
+			self.assertTrue(any(path.endswith("demo_control_IPB_0x10C_panel.xvp") for path in output_paths))
+			self.assertTrue(any(path.endswith("demo_control_EPS_0x06D_panel.xvp") for path in output_paths))
+			output_path = next(path for path in output_paths if path.endswith("demo_control_IPB_0x10C_panel.xvp"))
 			self.assertTrue(Path(output_path).exists())
 			root = ET.parse(output_path).getroot()
 			self.assertEqual("Panel", root.tag)

--- a/test_xvp_generator.py
+++ b/test_xvp_generator.py
@@ -71,6 +71,14 @@ class XvpGeneratorTests(unittest.TestCase):
 			self.assertIn("max: 102.2", group_texts)
 			self.assertIn("min: ~", group_texts)
 			self.assertIn("max: ~", group_texts)
+			min_text = next(
+				obj
+				for obj in root.findall(".//Object")
+				if any(prop.get("Name") == "Text" and prop.text == "min: 0" for prop in obj.findall("./Property"))
+			)
+			min_font = min_text.find("./Property[@Name='Font']")
+			self.assertIsNotNone(min_font)
+			self.assertEqual("Microsoft Sans Serif, 7pt", min_font.text)
 
 			object_types = [obj.get("Type", "") for obj in root.findall(".//Object")]
 			self.assertTrue(any("ComboBoxControl" in obj_type for obj_type in object_types))

--- a/test_xvp_generator.py
+++ b/test_xvp_generator.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from xml.etree import ElementTree as ET
+
+from xodr_converter.xvp_generator import generation_xvp
+
+
+SYSVAR_XML = """<?xml version="1.0" encoding="utf-8"?>
+<systemvariables version="4">
+  <namespace name="" comment="" interface="">
+    <namespace name="control" comment="" interface="">
+      <struct name="ipb_0x10c" isUnion="False" definedBinaryLayout="False" comment="">
+        <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="VehicleSpeed_Rv" comment="" bitcount="64" isSigned="false" encoding="65001" type="int" startValue="0" minValue="0" maxValue="3">
+          <valuetable name="VehicleSpeedVt" definesMinMax="false">
+            <valuetableentry value="0" lowerBound="0" upperBound="0" description="Invalid" displayString="Invalid" />
+            <valuetableentry value="1" lowerBound="1" upperBound="1" description="Close" displayString="Close" />
+          </valuetable>
+        </structMember>
+        <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="VehicleSpeed_Pv" comment="" bitcount="64" isSigned="false" encoding="65001" type="double" startValue="0" minValue="0" maxValue="102.2" />
+        <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="VehicleSpeed_use_special_value" comment="" bitcount="64" isSigned="false" encoding="65001" type="int" startValue="0" minValue="0" maxValue="1" />
+        <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="VehicleSpeed_use_inactive_value" comment="" bitcount="64" isSigned="false" encoding="65001" type="int" startValue="0" minValue="0" maxValue="1" />
+      </struct>
+      <variable anlyzLocal="2" readOnly="false" valueSequence="false" unit="" name="IPB_0x10C" comment="" bitcount="256" isSigned="true" encoding="65001" type="struct" structDefinition="control::ipb_0x10c" />
+      <variable anlyzLocal="2" readOnly="false" valueSequence="false" unit="" name="IPB_0x10C_Info" comment="" bitcount="128" isSigned="true" encoding="65001" type="struct" structDefinition="control::ipb_0x10c_info" />
+    </namespace>
+  </namespace>
+</systemvariables>
+"""
+
+
+class XvpGeneratorTests(unittest.TestCase):
+	def test_generates_xvp_for_selected_message_variables(self) -> None:
+		with tempfile.TemporaryDirectory() as temp_dir:
+			sysvar_path = Path(temp_dir) / "demo.vsysvar"
+			sysvar_path.write_text(SYSVAR_XML, encoding="utf-8")
+
+			output_path = generation_xvp(
+				str(sysvar_path),
+				{"control": ["IPB_0x10C"]},
+				temp_dir,
+			)
+
+			self.assertTrue(Path(output_path).exists())
+			root = ET.parse(output_path).getroot()
+			self.assertEqual("Panel", root.tag)
+
+			group_texts = [
+				prop.text
+				for prop in root.findall(".//Object/Property[@Name='Text']")
+				if prop.text
+			]
+			self.assertIn("Message Name: IPB_0x10C", group_texts)
+			self.assertIn("VehicleSpeed", group_texts)
+
+			object_types = [obj.get("Type", "") for obj in root.findall(".//Object")]
+			self.assertTrue(any("ComboBoxControl" in obj_type for obj_type in object_types))
+			self.assertTrue(any("TextBoxControl" in obj_type for obj_type in object_types))
+			self.assertTrue(any("RadioButtonControl" in obj_type for obj_type in object_types))
+
+			symbol_configurations = [
+				prop.text
+				for prop in root.findall(".//Property[@Name='SymbolConfiguration']")
+				if prop.text
+			]
+			self.assertIn(
+				"8;128;control;;IPB_0x10C;VehicleSpeed_Rv;2;;;-1;;;Value;;;0",
+				symbol_configurations,
+			)
+			self.assertIn(
+				"8;128;control;;IPB_0x10C;VehicleSpeed_Pv;2;;;-1;;;Value;;;0",
+				symbol_configurations,
+			)
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/test_xvp_generator.py
+++ b/test_xvp_generator.py
@@ -112,6 +112,19 @@ class XvpGeneratorTests(unittest.TestCase):
 			self.assertIsNotNone(alarm_settings)
 			self.assertEqual("1;102.2;0;3", alarm_settings.text)
 
+			no_range_text_box = next(
+				obj
+				for obj in root.findall(".//Object")
+				if any(
+					prop.get("Name") == "SymbolConfiguration"
+					and prop.text == "8;128;control;;IPB_0x10C;NoRange_Pv;2;;;-1;;;Value;;;0"
+					for prop in obj.findall("./Property")
+				)
+			)
+			no_range_alarm_settings = no_range_text_box.find("./Property[@Name='AlarmGeneralSettings']")
+			self.assertIsNotNone(no_range_alarm_settings)
+			self.assertEqual("1;2147483647;-2147483648;3", no_range_alarm_settings.text)
+
 
 if __name__ == "__main__":
 	unittest.main()

--- a/test_xvp_generator.py
+++ b/test_xvp_generator.py
@@ -13,6 +13,7 @@ SYSVAR_XML = """<?xml version="1.0" encoding="utf-8"?>
   <namespace name="" comment="" interface="">
     <namespace name="control" comment="" interface="">
       <struct name="ipb_0x10c" isUnion="False" definedBinaryLayout="False" comment="">
+        <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="IPB_0x10C_node" comment="" bitcount="0" isSigned="false" encoding="65001" type="string" startValue="IPB" />
         <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="VehicleSpeed_Rv" comment="" bitcount="64" isSigned="false" encoding="65001" type="int" startValue="0" minValue="0" maxValue="3">
           <valuetable name="VehicleSpeedVt" definesMinMax="false">
             <valuetableentry value="0" lowerBound="0" upperBound="0" description="Invalid" displayString="Invalid" />
@@ -28,6 +29,7 @@ SYSVAR_XML = """<?xml version="1.0" encoding="utf-8"?>
         <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="NumericRaw_Pv" comment="" bitcount="64" isSigned="false" encoding="65001" type="double" startValue="0" minValue="0" maxValue="409.5" />
       </struct>
       <struct name="eps_0x06d" isUnion="False" definedBinaryLayout="False" comment="">
+        <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="EPS_0x06D_node" comment="" bitcount="0" isSigned="false" encoding="65001" type="string" startValue="EPS" />
         <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="SteerAngle_Rv" comment="" bitcount="64" isSigned="true" encoding="65001" type="int" startValue="0" minValue="-7200" maxValue="7200" />
         <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="SteerAngle_Pv" comment="" bitcount="64" isSigned="true" encoding="65001" type="double" startValue="0" minValue="-720" maxValue="720" />
         <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="SteerAngle_use_special_value" comment="" bitcount="64" isSigned="false" encoding="65001" type="int" startValue="0" minValue="0" maxValue="1" />
@@ -55,9 +57,9 @@ class XvpGeneratorTests(unittest.TestCase):
 			)
 
 			self.assertEqual(2, len(output_paths))
-			self.assertTrue(any(path.endswith("demo_control_IPB_0x10C_panel.xvp") for path in output_paths))
-			self.assertTrue(any(path.endswith("demo_control_EPS_0x06D_panel.xvp") for path in output_paths))
-			output_path = next(path for path in output_paths if path.endswith("demo_control_IPB_0x10C_panel.xvp"))
+			self.assertTrue(any(path.endswith("control_IPB_IPB_0x10C_panel.xvp") for path in output_paths))
+			self.assertTrue(any(path.endswith("control_EPS_EPS_0x06D_panel.xvp") for path in output_paths))
+			output_path = next(path for path in output_paths if path.endswith("control_IPB_IPB_0x10C_panel.xvp"))
 			self.assertTrue(Path(output_path).exists())
 			root = ET.parse(output_path).getroot()
 			self.assertEqual("Panel", root.tag)

--- a/test_xvp_generator.py
+++ b/test_xvp_generator.py
@@ -78,7 +78,7 @@ class XvpGeneratorTests(unittest.TestCase):
 			)
 			min_font = min_text.find("./Property[@Name='Font']")
 			self.assertIsNotNone(min_font)
-			self.assertEqual("Microsoft Sans Serif, 7pt", min_font.text)
+			self.assertEqual("Microsoft Sans Serif, 9.25pt", min_font.text)
 
 			object_types = [obj.get("Type", "") for obj in root.findall(".//Object")]
 			self.assertTrue(any("ComboBoxControl" in obj_type for obj_type in object_types))

--- a/test_xvp_generator.py
+++ b/test_xvp_generator.py
@@ -102,6 +102,19 @@ class XvpGeneratorTests(unittest.TestCase):
 				symbol_configurations,
 			)
 
+			raw_combo_box = next(
+				obj
+				for obj in root.findall(".//Object")
+				if any(
+					prop.get("Name") == "SymbolConfiguration"
+					and prop.text == "8;128;control;;IPB_0x10C;VehicleSpeed_Rv;2;;;-1;;;Value;;;0"
+					for prop in obj.findall("./Property")
+				)
+			)
+			raw_combo_size = raw_combo_box.find("./Property[@Name='Size']")
+			self.assertIsNotNone(raw_combo_size)
+			self.assertEqual("120, 23", raw_combo_size.text)
+
 			physical_text_box = next(
 				obj
 				for obj in root.findall(".//Object")

--- a/test_xvp_generator.py
+++ b/test_xvp_generator.py
@@ -22,6 +22,8 @@ SYSVAR_XML = """<?xml version="1.0" encoding="utf-8"?>
         <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="VehicleSpeed_Pv" comment="" bitcount="64" isSigned="false" encoding="65001" type="double" startValue="0" minValue="0" maxValue="102.2" />
         <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="VehicleSpeed_use_special_value" comment="" bitcount="64" isSigned="false" encoding="65001" type="int" startValue="0" minValue="0" maxValue="1" />
         <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="VehicleSpeed_use_inactive_value" comment="" bitcount="64" isSigned="false" encoding="65001" type="int" startValue="0" minValue="0" maxValue="1" />
+        <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="NoRange_Rv" comment="" bitcount="64" isSigned="false" encoding="65001" type="int" startValue="0" />
+        <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="NoRange_Pv" comment="" bitcount="64" isSigned="false" encoding="65001" type="double" startValue="0" />
       </struct>
       <struct name="eps_0x06d" isUnion="False" definedBinaryLayout="False" comment="">
         <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="SteerAngle_Rv" comment="" bitcount="64" isSigned="true" encoding="65001" type="int" startValue="0" minValue="-7200" maxValue="7200" />
@@ -65,6 +67,8 @@ class XvpGeneratorTests(unittest.TestCase):
 			]
 			self.assertIn("Message Name: IPB_0x10C", group_texts)
 			self.assertIn("VehicleSpeed", group_texts)
+			self.assertIn("min: 0    max: 102.2", group_texts)
+			self.assertIn("min: ~    max: ~", group_texts)
 
 			object_types = [obj.get("Type", "") for obj in root.findall(".//Object")]
 			self.assertTrue(any("ComboBoxControl" in obj_type for obj_type in object_types))

--- a/test_xvp_generator.py
+++ b/test_xvp_generator.py
@@ -110,7 +110,7 @@ class XvpGeneratorTests(unittest.TestCase):
 			)
 			alarm_settings = physical_text_box.find("./Property[@Name='AlarmGeneralSettings']")
 			self.assertIsNotNone(alarm_settings)
-			self.assertEqual("1;102.2;0;3", alarm_settings.text)
+			self.assertEqual("1;3;0;102.2", alarm_settings.text)
 			physical_value_display = physical_text_box.find("./Property[@Name='ValueDisplay']")
 			self.assertIsNotNone(physical_value_display)
 			self.assertEqual("Double", physical_value_display.text)
@@ -139,7 +139,7 @@ class XvpGeneratorTests(unittest.TestCase):
 			)
 			no_range_alarm_settings = no_range_text_box.find("./Property[@Name='AlarmGeneralSettings']")
 			self.assertIsNotNone(no_range_alarm_settings)
-			self.assertEqual("1;2147483647;-2147483648;3", no_range_alarm_settings.text)
+			self.assertEqual("1;3;-2147483648;2147483647", no_range_alarm_settings.text)
 
 
 if __name__ == "__main__":

--- a/xodr_converter/dbc_to_vsysvar.py
+++ b/xodr_converter/dbc_to_vsysvar.py
@@ -56,6 +56,7 @@ class DbcMessage:
 
 @dataclass
 class DbcDatabase:
+	nodes: List[str]
 	messages: List[DbcMessage]
 
 
@@ -83,7 +84,10 @@ def parse_dbc_text(text: str) -> DbcDatabase:
 		strict=False,
 		sort_signals=None,
 	)
-	return DbcDatabase(messages=[convert_cantools_message(message) for message in database.messages])
+	return DbcDatabase(
+		nodes=[node.name for node in database.nodes],
+		messages=[convert_cantools_message(message) for message in database.messages],
+	)
 
 
 def convert_cantools_message(message) -> DbcMessage:
@@ -252,6 +256,7 @@ def build_vsysvar_tree(dbc_specs: Sequence[Tuple[str, DbcDatabase]]) -> ET.Eleme
 
 	for namespace_name, database in dbc_specs:
 		namespace_element = ET.SubElement(root_namespace, "namespace", namespace_attrs(namespace_name))
+		add_node_info_struct(namespace_element, namespace_name, database.nodes)
 		for message in database.messages:
 			add_message_info_struct_and_variable(namespace_element, namespace_name, message)
 			add_message_struct_and_variable(namespace_element, namespace_name, message)
@@ -263,6 +268,35 @@ def build_vsysvar_tree(dbc_specs: Sequence[Tuple[str, DbcDatabase]]) -> ET.Eleme
 
 def namespace_attrs(name: str) -> Dict[str, str]:
 	return {"name": name, "comment": "", "interface": ""}
+
+
+def add_node_info_struct(namespace_element: ET.Element, namespace_name: str, nodes: Sequence[str]) -> None:
+	struct_element = ET.SubElement(
+		namespace_element,
+		"struct",
+		{
+			"name": f"{namespace_name.lower()}_node_info",
+			"isUnion": "False",
+			"definedBinaryLayout": "False",
+			"comment": "",
+		},
+	)
+
+	for node_name in nodes:
+		ET.SubElement(
+			struct_element,
+			"structMember",
+			struct_member_attrs(
+				name=f"{node_name}_MsgOn",
+				comment="",
+				is_signed=False,
+				member_type="int",
+				start_value=Decimal("1"),
+				min_value=Decimal("0"),
+				max_value=Decimal("1"),
+				bitcount=32,
+			),
+		)
 
 
 def add_message_info_struct_and_variable(

--- a/xodr_converter/dbc_to_vsysvar.py
+++ b/xodr_converter/dbc_to_vsysvar.py
@@ -82,7 +82,6 @@ def parse_dbc_file(path: str) -> DbcDatabase:
 
 def parse_dbc_text(text: str) -> DbcDatabase:
 	messages: List[DbcMessage] = []
-	message_by_id: Dict[int, DbcMessage] = {}
 	signal_by_key: Dict[Tuple[int, str], DbcSignal] = {}
 	comments: Dict[Tuple[int, str], str] = {}
 	start_values: Dict[Tuple[int, str], Decimal] = {}
@@ -102,7 +101,6 @@ def parse_dbc_text(text: str) -> DbcDatabase:
 				sender=message_match.group("sender"),
 			)
 			messages.append(current_message)
-			message_by_id[current_message.frame_id] = current_message
 			continue
 
 		signal_match = SIGNAL_RE.match(line)

--- a/xodr_converter/dbc_to_vsysvar.py
+++ b/xodr_converter/dbc_to_vsysvar.py
@@ -529,6 +529,10 @@ def should_use_int_for_physical_value(signal: DbcSignal) -> bool:
 		return False
 	if signal.factor != signal.factor.to_integral_value():
 		return False
+	if signal.minimum != signal.minimum.to_integral_value():
+		return False
+	if signal.maximum != signal.maximum.to_integral_value():
+		return False
 	return (
 		INT_MIN_VALUE <= signal.minimum <= INT_MAX_VALUE
 		and INT_MIN_VALUE <= signal.maximum <= INT_MAX_VALUE

--- a/xodr_converter/dbc_to_vsysvar.py
+++ b/xodr_converter/dbc_to_vsysvar.py
@@ -499,21 +499,21 @@ def add_message_struct_and_variable(
 			value_table_entries = member_value_table_entries(signal, suffix, member_type, normal_choices)
 			if include_value_table and value_table_entries:
 				add_value_table(member_element, f"{signal.name}Vt", value_table_entries)
-			bitcount += 64
+			bitcount += member_bitcount(member_type)
 		add_has_special_value_member(struct_element, signal, has_special_value=bool(special_choices))
-		bitcount += 64
+		bitcount += member_bitcount("int")
 		add_use_special_value_member(struct_element, signal)
-		bitcount += 64
+		bitcount += member_bitcount("int")
 		if special_choices:
 			add_special_value_member(struct_element, signal, special_choices)
-			bitcount += 64
+			bitcount += member_bitcount("int")
 		add_has_inactive_value_member(struct_element, signal)
-		bitcount += 64
+		bitcount += member_bitcount("int")
 		add_use_inactive_value_member(struct_element, signal)
-		bitcount += 64
+		bitcount += member_bitcount("int")
 		if signal.inactive_raw is not None:
 			add_inactive_value_member(struct_element, signal)
-			bitcount += 64
+			bitcount += member_bitcount("int")
 
 	ET.SubElement(
 		namespace_element,
@@ -759,7 +759,7 @@ def struct_member_attrs(
 	max_value: Optional[Decimal],
 	bitcount: int = 64,
 ) -> Dict[str, str]:
-	actual_bitcount = 32 if member_type == "int" else bitcount
+	actual_bitcount = member_bitcount(member_type, bitcount)
 	attrs = {
 		"relativeOffset": "0",
 		"byteOrder": "0",
@@ -778,6 +778,12 @@ def struct_member_attrs(
 	if max_value is not None and should_write_bound(member_type, max_value):
 		attrs["maxValue"] = decimal_to_text(max_value)
 	return attrs
+
+
+def member_bitcount(member_type: str, bitcount: int = 64) -> int:
+	if member_type == "int":
+		return 32
+	return bitcount
 
 
 def value_to_text(value: Union[Decimal, str]) -> str:

--- a/xodr_converter/dbc_to_vsysvar.py
+++ b/xodr_converter/dbc_to_vsysvar.py
@@ -492,11 +492,12 @@ def add_message_struct_and_variable(
 			if include_value_table and normal_choices:
 				add_value_table(member_element, f"{signal.name}Vt", normal_choices)
 			bitcount += 64
-		add_has_special_value_member(struct_element, signal)
+		add_has_special_value_member(struct_element, signal, has_special_value=bool(special_choices))
 		bitcount += 64
 		if special_choices:
+			add_use_special_value_member(struct_element, signal)
 			add_special_value_member(struct_element, signal, special_choices)
-			bitcount += 64
+			bitcount += 128
 
 	ET.SubElement(
 		namespace_element,
@@ -517,7 +518,9 @@ def add_message_struct_and_variable(
 	)
 
 
-def add_has_special_value_member(struct_element: ET.Element, signal: DbcSignal) -> None:
+def add_has_special_value_member(
+	struct_element: ET.Element, signal: DbcSignal, has_special_value: bool
+) -> None:
 	has_special_member = ET.SubElement(
 		struct_element,
 		"structMember",
@@ -526,7 +529,7 @@ def add_has_special_value_member(struct_element: ET.Element, signal: DbcSignal) 
 			comment="",
 			is_signed=False,
 			member_type="int",
-			start_value=Decimal("0"),
+			start_value=Decimal("1") if has_special_value else Decimal("0"),
 			min_value=Decimal("0"),
 			max_value=Decimal("1"),
 		),
@@ -537,6 +540,30 @@ def add_has_special_value_member(struct_element: ET.Element, signal: DbcSignal) 
 		[
 			ValueTableEntry(Decimal("0"), "no"),
 			ValueTableEntry(Decimal("1"), "yes"),
+		],
+	)
+
+
+def add_use_special_value_member(struct_element: ET.Element, signal: DbcSignal) -> None:
+	use_special_member = ET.SubElement(
+		struct_element,
+		"structMember",
+		struct_member_attrs(
+			name=f"{signal.name}_use_special_value",
+			comment="",
+			is_signed=False,
+			member_type="int",
+			start_value=Decimal("0"),
+			min_value=Decimal("0"),
+			max_value=Decimal("1"),
+		),
+	)
+	add_value_table(
+		use_special_member,
+		f"{signal.name}_use_special_valueVt",
+		[
+			ValueTableEntry(Decimal("0"), "not use"),
+			ValueTableEntry(Decimal("1"), "use"),
 		],
 	)
 

--- a/xodr_converter/dbc_to_vsysvar.py
+++ b/xodr_converter/dbc_to_vsysvar.py
@@ -5,7 +5,7 @@ import os
 import re
 from dataclasses import dataclass, field
 from decimal import Decimal, ROUND_CEILING, ROUND_FLOOR
-from typing import Dict, Iterable, List, Optional, Sequence, Tuple
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple, Union
 from xml.etree import ElementTree as ET
 
 import cantools
@@ -455,6 +455,21 @@ def add_message_struct_and_variable(
 		},
 	)
 
+	ET.SubElement(
+		struct_element,
+		"structMember",
+		struct_member_attrs(
+			name=f"{message.name}_node",
+			comment="",
+			is_signed=False,
+			member_type="string",
+			start_value=message.sender,
+			min_value=None,
+			max_value=None,
+			bitcount=0,
+		),
+	)
+
 	bitcount = 0
 	for signal in message.signals:
 		for suffix, member_type, start_value, min_value, max_value, include_value_table in signal_member_specs(signal):
@@ -512,7 +527,7 @@ def struct_member_attrs(
 	comment: str,
 	is_signed: bool,
 	member_type: str,
-	start_value: Decimal,
+	start_value: Union[Decimal, str],
 	min_value: Optional[Decimal],
 	max_value: Optional[Decimal],
 	bitcount: int = 64,
@@ -528,13 +543,19 @@ def struct_member_attrs(
 		"isSigned": "true" if is_signed else "false",
 		"encoding": "65001",
 		"type": member_type,
-		"startValue": decimal_to_text(start_value),
+		"startValue": value_to_text(start_value),
 	}
 	if min_value is not None and should_write_bound(member_type, min_value):
 		attrs["minValue"] = decimal_to_text(min_value)
 	if max_value is not None and should_write_bound(member_type, max_value):
 		attrs["maxValue"] = decimal_to_text(max_value)
 	return attrs
+
+
+def value_to_text(value: Union[Decimal, str]) -> str:
+	if isinstance(value, Decimal):
+		return decimal_to_text(value)
+	return value
 
 
 def should_write_bound(member_type: str, value: Decimal) -> bool:

--- a/xodr_converter/dbc_to_vsysvar.py
+++ b/xodr_converter/dbc_to_vsysvar.py
@@ -496,8 +496,9 @@ def add_message_struct_and_variable(
 					max_value=max_value,
 				),
 			)
-			if include_value_table and normal_choices:
-				add_value_table(member_element, f"{signal.name}Vt", normal_choices)
+			value_table_entries = member_value_table_entries(signal, suffix, member_type, normal_choices)
+			if include_value_table and value_table_entries:
+				add_value_table(member_element, f"{signal.name}Vt", value_table_entries)
 			bitcount += 64
 		add_has_special_value_member(struct_element, signal, has_special_value=bool(special_choices))
 		bitcount += 64
@@ -684,8 +685,6 @@ def signal_member_specs(
 
 
 def should_use_int_for_physical_value(signal: DbcSignal) -> bool:
-	if normal_value_table_choices(signal):
-		return True
 	if signal.offset != 0:
 		return False
 	if signal.factor != signal.factor.to_integral_value():
@@ -697,7 +696,41 @@ def should_use_int_for_physical_value(signal: DbcSignal) -> bool:
 	return (
 		INT_MIN_VALUE <= signal.minimum <= INT_MAX_VALUE
 		and INT_MIN_VALUE <= signal.maximum <= INT_MAX_VALUE
+		and all(
+			is_integral_decimal(raw_to_physical_value(signal, entry.value))
+			for entry in normal_value_table_choices(signal)
+		)
 	)
+
+
+def member_value_table_entries(
+	signal: DbcSignal,
+	suffix: str,
+	member_type: str,
+	normal_choices: List[ValueTableEntry],
+) -> List[ValueTableEntry]:
+	if suffix == "Rv":
+		return normal_choices
+	if suffix == "Pv" and member_type == "int":
+		return physical_value_table_choices(signal, normal_choices)
+	return []
+
+
+def physical_value_table_choices(
+	signal: DbcSignal, choices: List[ValueTableEntry]
+) -> List[ValueTableEntry]:
+	return [
+		ValueTableEntry(raw_to_physical_value(signal, entry.value), entry.description)
+		for entry in choices
+	]
+
+
+def raw_to_physical_value(signal: DbcSignal, raw_value: Decimal) -> Decimal:
+	return raw_value * signal.factor + signal.offset
+
+
+def is_integral_decimal(value: Decimal) -> bool:
+	return value == value.to_integral_value()
 
 
 def normal_value_table_choices(signal: DbcSignal) -> List[ValueTableEntry]:

--- a/xodr_converter/dbc_to_vsysvar.py
+++ b/xodr_converter/dbc_to_vsysvar.py
@@ -12,6 +12,12 @@ import cantools
 
 
 @dataclass
+class ValueTableEntry:
+	value: Decimal
+	description: str
+
+
+@dataclass
 class DbcSignal:
 	name: str
 	start_bit: int
@@ -26,6 +32,7 @@ class DbcSignal:
 	receivers: List[str]
 	comment: str = ""
 	start_raw: Decimal = Decimal("0")
+	choices: List[ValueTableEntry] = field(default_factory=list)
 
 
 @dataclass
@@ -95,7 +102,23 @@ def convert_cantools_signal(signal) -> DbcSignal:
 		receivers=list(signal.receivers),
 		comment=signal.comment or "",
 		start_raw=to_decimal(signal.raw_initial, Decimal("0")),
+		choices=convert_cantools_choices(signal.choices),
 	)
+
+
+def convert_cantools_choices(choices) -> List[ValueTableEntry]:
+	if not choices:
+		return []
+
+	entries: List[ValueTableEntry] = []
+	for value, description in choices.items():
+		entries.append(
+			ValueTableEntry(
+				value=to_decimal(value, Decimal("0")),
+				description=str(description),
+			)
+		)
+	return sorted(entries, key=lambda entry: entry.value)
 
 
 def to_decimal(value, default: Decimal) -> Decimal:
@@ -168,8 +191,8 @@ def add_message_struct_and_variable(
 
 	bitcount = 0
 	for signal in message.signals:
-		for suffix, member_type, start_value, min_value, max_value in signal_member_specs(signal):
-			ET.SubElement(
+		for suffix, member_type, start_value, min_value, max_value, include_value_table in signal_member_specs(signal):
+			member_element = ET.SubElement(
 				struct_element,
 				"structMember",
 				struct_member_attrs(
@@ -182,6 +205,8 @@ def add_message_struct_and_variable(
 					max_value=max_value,
 				),
 			)
+			if include_value_table and signal.choices:
+				add_value_table(member_element, signal)
 			bitcount += 64
 
 	ET.SubElement(
@@ -205,13 +230,13 @@ def add_message_struct_and_variable(
 
 def signal_member_specs(
 	signal: DbcSignal,
-) -> Iterable[Tuple[str, str, Decimal, Optional[Decimal], Optional[Decimal]]]:
+) -> Iterable[Tuple[str, str, Decimal, Optional[Decimal], Optional[Decimal], bool]]:
 	raw_min, raw_max = raw_range_from_physical(signal)
 	return (
-		("Pv", "double", physical_start_value(signal), signal.minimum, signal.maximum),
-		("Rv", "int", signal.start_raw, raw_min, raw_max),
-		("Factor", "double", signal.factor, None, None),
-		("Offset", "double", signal.offset, None, None),
+		("Pv", "double", physical_start_value(signal), signal.minimum, signal.maximum, True),
+		("Rv", "int", signal.start_raw, raw_min, raw_max, True),
+		("Factor", "double", signal.factor, None, None, False),
+		("Offset", "double", signal.offset, None, None, False),
 	)
 
 
@@ -242,6 +267,30 @@ def struct_member_attrs(
 	if max_value is not None:
 		attrs["maxValue"] = decimal_to_text(max_value)
 	return attrs
+
+
+def add_value_table(member_element: ET.Element, signal: DbcSignal) -> None:
+	value_table = ET.SubElement(
+		member_element,
+		"valuetable",
+		{
+			"name": signal.name,
+			"definesMinMax": "false",
+		},
+	)
+	for entry in signal.choices:
+		value = decimal_to_text(entry.value)
+		ET.SubElement(
+			value_table,
+			"valuetableentry",
+			{
+				"value": value,
+				"lowerBound": value,
+				"upperBound": value,
+				"description": entry.description,
+				"displayString": entry.description,
+			},
+		)
 
 
 def write_vsysvar_file(tree: ET.ElementTree, output_path: str) -> None:

--- a/xodr_converter/dbc_to_vsysvar.py
+++ b/xodr_converter/dbc_to_vsysvar.py
@@ -11,6 +11,10 @@ from xml.etree import ElementTree as ET
 import cantools
 
 
+INT_MIN_VALUE = Decimal("-2147483648")
+INT_MAX_VALUE = Decimal("2147483647")
+
+
 @dataclass
 class ValueTableEntry:
 	value: Decimal
@@ -526,11 +530,17 @@ def struct_member_attrs(
 		"type": member_type,
 		"startValue": decimal_to_text(start_value),
 	}
-	if min_value is not None:
+	if min_value is not None and should_write_bound(member_type, min_value):
 		attrs["minValue"] = decimal_to_text(min_value)
-	if max_value is not None:
+	if max_value is not None and should_write_bound(member_type, max_value):
 		attrs["maxValue"] = decimal_to_text(max_value)
 	return attrs
+
+
+def should_write_bound(member_type: str, value: Decimal) -> bool:
+	if member_type != "int":
+		return True
+	return INT_MIN_VALUE <= value <= INT_MAX_VALUE
 
 
 def add_value_table(

--- a/xodr_converter/dbc_to_vsysvar.py
+++ b/xodr_converter/dbc_to_vsysvar.py
@@ -51,6 +51,7 @@ class DbcSignal:
 	start_raw: Decimal = Decimal("0")
 	choices: List[ValueTableEntry] = field(default_factory=list)
 	inactive_raw: Optional[Decimal] = None
+	multiplexer_ids: List[int] = field(default_factory=list)
 
 
 @dataclass
@@ -157,6 +158,7 @@ def convert_cantools_signal(signal) -> DbcSignal:
 		start_raw=to_decimal(signal.raw_initial, Decimal("0")),
 		choices=convert_cantools_choices(signal.choices),
 		inactive_raw=to_optional_decimal(get_signal_attribute_value(signal, "GenSigInactiveValue")),
+		multiplexer_ids=list(signal.multiplexer_ids or []),
 	)
 
 
@@ -480,6 +482,7 @@ def add_message_struct_and_variable(
 
 	bitcount = 0
 	for signal in message.signals:
+		member_base_name = signal_member_base_name(signal)
 		normal_choices = normal_value_table_choices(signal)
 		special_choices = special_value_table_choices(signal)
 		for suffix, member_type, start_value, min_value, max_value, include_value_table in signal_member_specs(signal):
@@ -487,7 +490,7 @@ def add_message_struct_and_variable(
 				struct_element,
 				"structMember",
 				struct_member_attrs(
-					name=f"{signal.name}_{suffix}",
+					name=f"{member_base_name}_{suffix}",
 					comment=signal.comment,
 					is_signed=signal.is_signed,
 					member_type=member_type,
@@ -497,7 +500,7 @@ def add_message_struct_and_variable(
 				),
 			)
 			if include_value_table and normal_choices:
-				add_value_table(member_element, f"{signal.name}Vt", normal_choices)
+				add_value_table(member_element, f"{member_base_name}Vt", normal_choices)
 			bitcount += 64
 		add_has_special_value_member(struct_element, signal, has_special_value=bool(special_choices))
 		bitcount += 64
@@ -531,14 +534,22 @@ def add_message_struct_and_variable(
 	)
 
 
+def signal_member_base_name(signal: DbcSignal) -> str:
+	if not signal.multiplexer_ids:
+		return signal.name
+	mux_suffix = "_".join(f"m{mux_id}" for mux_id in signal.multiplexer_ids)
+	return f"{signal.name}_{mux_suffix}"
+
+
 def add_has_special_value_member(
 	struct_element: ET.Element, signal: DbcSignal, has_special_value: bool
 ) -> None:
+	member_base_name = signal_member_base_name(signal)
 	has_special_member = ET.SubElement(
 		struct_element,
 		"structMember",
 		struct_member_attrs(
-			name=f"{signal.name}_has_special_value",
+			name=f"{member_base_name}_has_special_value",
 			comment="",
 			is_signed=False,
 			member_type="int",
@@ -549,7 +560,7 @@ def add_has_special_value_member(
 	)
 	add_value_table(
 		has_special_member,
-		f"{signal.name}_has_special_valueVt",
+		f"{member_base_name}_has_special_valueVt",
 		[
 			ValueTableEntry(Decimal("0"), "no"),
 			ValueTableEntry(Decimal("1"), "yes"),
@@ -558,11 +569,12 @@ def add_has_special_value_member(
 
 
 def add_use_special_value_member(struct_element: ET.Element, signal: DbcSignal) -> None:
+	member_base_name = signal_member_base_name(signal)
 	use_special_member = ET.SubElement(
 		struct_element,
 		"structMember",
 		struct_member_attrs(
-			name=f"{signal.name}_use_special_value",
+			name=f"{member_base_name}_use_special_value",
 			comment="",
 			is_signed=False,
 			member_type="int",
@@ -573,7 +585,7 @@ def add_use_special_value_member(struct_element: ET.Element, signal: DbcSignal) 
 	)
 	add_value_table(
 		use_special_member,
-		f"{signal.name}_use_special_valueVt",
+		f"{member_base_name}_use_special_valueVt",
 		[
 			ValueTableEntry(Decimal("0"), "not use"),
 			ValueTableEntry(Decimal("1"), "use"),
@@ -584,11 +596,12 @@ def add_use_special_value_member(struct_element: ET.Element, signal: DbcSignal) 
 def add_special_value_member(
 	struct_element: ET.Element, signal: DbcSignal, special_choices: List[ValueTableEntry]
 ) -> None:
+	member_base_name = signal_member_base_name(signal)
 	special_value_member = ET.SubElement(
 		struct_element,
 		"structMember",
 		struct_member_attrs(
-			name=f"{signal.name}_special_value",
+			name=f"{member_base_name}_special_value",
 			comment="",
 			is_signed=signal.is_signed,
 			member_type="int",
@@ -597,15 +610,16 @@ def add_special_value_member(
 			max_value=None,
 		),
 	)
-	add_value_table(special_value_member, f"{signal.name}_special_valueVt", special_choices)
+	add_value_table(special_value_member, f"{member_base_name}_special_valueVt", special_choices)
 
 
 def add_has_inactive_value_member(struct_element: ET.Element, signal: DbcSignal) -> None:
+	member_base_name = signal_member_base_name(signal)
 	has_inactive_member = ET.SubElement(
 		struct_element,
 		"structMember",
 		struct_member_attrs(
-			name=f"{signal.name}_has_inactive_value",
+			name=f"{member_base_name}_has_inactive_value",
 			comment="",
 			is_signed=False,
 			member_type="int",
@@ -616,7 +630,7 @@ def add_has_inactive_value_member(struct_element: ET.Element, signal: DbcSignal)
 	)
 	add_value_table(
 		has_inactive_member,
-		f"{signal.name}_has_inactive_valueVt",
+		f"{member_base_name}_has_inactive_valueVt",
 		[
 			ValueTableEntry(Decimal("0"), "no"),
 			ValueTableEntry(Decimal("1"), "yes"),
@@ -625,11 +639,12 @@ def add_has_inactive_value_member(struct_element: ET.Element, signal: DbcSignal)
 
 
 def add_use_inactive_value_member(struct_element: ET.Element, signal: DbcSignal) -> None:
+	member_base_name = signal_member_base_name(signal)
 	use_inactive_member = ET.SubElement(
 		struct_element,
 		"structMember",
 		struct_member_attrs(
-			name=f"{signal.name}_use_inactive_value",
+			name=f"{member_base_name}_use_inactive_value",
 			comment="",
 			is_signed=False,
 			member_type="int",
@@ -640,7 +655,7 @@ def add_use_inactive_value_member(struct_element: ET.Element, signal: DbcSignal)
 	)
 	add_value_table(
 		use_inactive_member,
-		f"{signal.name}_use_inactive_valueVt",
+		f"{member_base_name}_use_inactive_valueVt",
 		[
 			ValueTableEntry(Decimal("0"), "not use"),
 			ValueTableEntry(Decimal("1"), "use"),
@@ -649,12 +664,13 @@ def add_use_inactive_value_member(struct_element: ET.Element, signal: DbcSignal)
 
 
 def add_inactive_value_member(struct_element: ET.Element, signal: DbcSignal) -> None:
+	member_base_name = signal_member_base_name(signal)
 	inactive_raw = signal.inactive_raw if signal.inactive_raw is not None else Decimal("0")
 	inactive_value_member = ET.SubElement(
 		struct_element,
 		"structMember",
 		struct_member_attrs(
-			name=f"{signal.name}_inactive_value",
+			name=f"{member_base_name}_inactive_value",
 			comment="",
 			is_signed=signal.is_signed,
 			member_type="int",
@@ -665,7 +681,7 @@ def add_inactive_value_member(struct_element: ET.Element, signal: DbcSignal) -> 
 	)
 	add_value_table(
 		inactive_value_member,
-		f"{signal.name}_inactive_valueVt",
+		f"{member_base_name}_inactive_valueVt",
 		[ValueTableEntry(inactive_raw, "inactive")],
 	)
 

--- a/xodr_converter/dbc_to_vsysvar.py
+++ b/xodr_converter/dbc_to_vsysvar.py
@@ -271,17 +271,19 @@ def namespace_attrs(name: str) -> Dict[str, str]:
 
 
 def add_node_info_struct(namespace_element: ET.Element, namespace_name: str, nodes: Sequence[str]) -> None:
+	struct_name = f"{namespace_name.lower()}_node_info"
 	struct_element = ET.SubElement(
 		namespace_element,
 		"struct",
 		{
-			"name": f"{namespace_name.lower()}_node_info",
+			"name": struct_name,
 			"isUnion": "False",
 			"definedBinaryLayout": "False",
 			"comment": "",
 		},
 	)
 
+	member_count = 0
 	for node_name in nodes:
 		ET.SubElement(
 			struct_element,
@@ -297,6 +299,25 @@ def add_node_info_struct(namespace_element: ET.Element, namespace_name: str, nod
 				bitcount=32,
 			),
 		)
+		member_count += 1
+
+	ET.SubElement(
+		namespace_element,
+		"variable",
+		{
+			"anlyzLocal": "2",
+			"readOnly": "false",
+			"valueSequence": "false",
+			"unit": "",
+			"name": f"{namespace_name}_Node_Info",
+			"comment": "",
+			"bitcount": str(member_count * 32),
+			"isSigned": "true",
+			"encoding": "65001",
+			"type": "struct",
+			"structDefinition": f"{namespace_name}::{struct_name}",
+		},
+	)
 
 
 def add_message_info_struct_and_variable(

--- a/xodr_converter/dbc_to_vsysvar.py
+++ b/xodr_converter/dbc_to_vsysvar.py
@@ -50,6 +50,7 @@ class DbcSignal:
 	comment: str = ""
 	start_raw: Decimal = Decimal("0")
 	choices: List[ValueTableEntry] = field(default_factory=list)
+	inactive_raw: Optional[Decimal] = None
 
 
 @dataclass
@@ -155,6 +156,7 @@ def convert_cantools_signal(signal) -> DbcSignal:
 		comment=signal.comment or "",
 		start_raw=to_decimal(signal.raw_initial, Decimal("0")),
 		choices=convert_cantools_choices(signal.choices),
+		inactive_raw=to_optional_decimal(get_signal_attribute_value(signal, "GenSigInactiveValue")),
 	)
 
 
@@ -182,6 +184,11 @@ def default_send_type_choices() -> List[ValueTableEntry]:
 
 def get_message_attribute_value(message, name: str):
 	attribute = getattr(message.dbc, "_attributes", {}).get(name) if message.dbc else None
+	return getattr(attribute, "value", None) if attribute is not None else None
+
+
+def get_signal_attribute_value(signal, name: str):
+	attribute = getattr(signal.dbc, "_attributes", {}).get(name) if signal.dbc else None
 	return getattr(attribute, "value", None) if attribute is not None else None
 
 
@@ -498,6 +505,12 @@ def add_message_struct_and_variable(
 			add_use_special_value_member(struct_element, signal)
 			add_special_value_member(struct_element, signal, special_choices)
 			bitcount += 128
+		add_has_inactive_value_member(struct_element, signal)
+		bitcount += 64
+		if signal.inactive_raw is not None:
+			add_use_inactive_value_member(struct_element, signal)
+			add_inactive_value_member(struct_element, signal)
+			bitcount += 128
 
 	ET.SubElement(
 		namespace_element,
@@ -585,6 +598,76 @@ def add_special_value_member(
 		),
 	)
 	add_value_table(special_value_member, f"{signal.name}_special_valueVt", special_choices)
+
+
+def add_has_inactive_value_member(struct_element: ET.Element, signal: DbcSignal) -> None:
+	has_inactive_member = ET.SubElement(
+		struct_element,
+		"structMember",
+		struct_member_attrs(
+			name=f"{signal.name}_has_inactive_value",
+			comment="",
+			is_signed=False,
+			member_type="int",
+			start_value=Decimal("1") if signal.inactive_raw is not None else Decimal("0"),
+			min_value=Decimal("0"),
+			max_value=Decimal("1"),
+		),
+	)
+	add_value_table(
+		has_inactive_member,
+		f"{signal.name}_has_inactive_valueVt",
+		[
+			ValueTableEntry(Decimal("0"), "no"),
+			ValueTableEntry(Decimal("1"), "yes"),
+		],
+	)
+
+
+def add_use_inactive_value_member(struct_element: ET.Element, signal: DbcSignal) -> None:
+	use_inactive_member = ET.SubElement(
+		struct_element,
+		"structMember",
+		struct_member_attrs(
+			name=f"{signal.name}_use_inactive_value",
+			comment="",
+			is_signed=False,
+			member_type="int",
+			start_value=Decimal("0"),
+			min_value=Decimal("0"),
+			max_value=Decimal("1"),
+		),
+	)
+	add_value_table(
+		use_inactive_member,
+		f"{signal.name}_use_inactive_valueVt",
+		[
+			ValueTableEntry(Decimal("0"), "not use"),
+			ValueTableEntry(Decimal("1"), "use"),
+		],
+	)
+
+
+def add_inactive_value_member(struct_element: ET.Element, signal: DbcSignal) -> None:
+	inactive_raw = signal.inactive_raw if signal.inactive_raw is not None else Decimal("0")
+	inactive_value_member = ET.SubElement(
+		struct_element,
+		"structMember",
+		struct_member_attrs(
+			name=f"{signal.name}_inactive_value",
+			comment="",
+			is_signed=signal.is_signed,
+			member_type="int",
+			start_value=inactive_raw,
+			min_value=None,
+			max_value=None,
+		),
+	)
+	add_value_table(
+		inactive_value_member,
+		f"{signal.name}_inactive_valueVt",
+		[ValueTableEntry(inactive_raw, "inactive")],
+	)
 
 
 def signal_member_specs(

--- a/xodr_converter/dbc_to_vsysvar.py
+++ b/xodr_converter/dbc_to_vsysvar.py
@@ -51,44 +51,28 @@ def read_text_file(path: str, encoding: Optional[str] = None) -> str:
 
 
 def decode_dbc_bytes(data: bytes, preferred_encoding: Optional[str] = None) -> str:
-	candidates = unique_encodings(
-		[preferred_encoding, "utf-8-sig", "utf-8", "gb18030", "gbk", "cp936", "cp1252"]
-	)
-	best_text = ""
-	best_score: Optional[Tuple[int, int, int]] = None
+	if preferred_encoding:
+		return data.decode(preferred_encoding, errors="replace")
 
-	for index, candidate in enumerate(candidates):
-		text = data.decode(candidate, errors="replace")
-		score = score_decoded_text(text, preferred=candidate == preferred_encoding, order=index)
-		if best_score is None or score > best_score:
-			best_text = text
-			best_score = score
+	for candidate in unique_encodings(["utf-8-sig", "utf-8", "gb18030", "gbk", "cp936", "cp1252"]):
+		try:
+			return data.decode(candidate)
+		except UnicodeDecodeError:
+			continue
 
-	return best_text
+	return data.decode("utf-8", errors="replace")
 
 
-def unique_encodings(encodings: Sequence[Optional[str]]) -> List[str]:
+def unique_encodings(encodings: Sequence[str]) -> List[str]:
 	unique: List[str] = []
 	seen = set()
 	for encoding in encodings:
-		if not encoding:
-			continue
 		normalized = encoding.lower()
 		if normalized in seen:
 			continue
 		seen.add(normalized)
 		unique.append(encoding)
 	return unique
-
-
-def score_decoded_text(text: str, preferred: bool, order: int) -> Tuple[int, int, int]:
-	replacement_count = text.count("\ufffd")
-	cjk_count = sum(1 for char in text if "\u4e00" <= char <= "\u9fff")
-	mojibake_count = sum(1 for char in text if char in "ÃÂÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞß")
-	score = cjk_count * 20 - replacement_count * 100 - mojibake_count * 10
-	if preferred:
-		score += 5
-	return score, -replacement_count, -order
 
 
 def parse_dbc_file(path: str, encoding: Optional[str] = None) -> DbcDatabase:

--- a/xodr_converter/dbc_to_vsysvar.py
+++ b/xodr_converter/dbc_to_vsysvar.py
@@ -232,8 +232,9 @@ def signal_member_specs(
 	signal: DbcSignal,
 ) -> Iterable[Tuple[str, str, Decimal, Optional[Decimal], Optional[Decimal], bool]]:
 	raw_min, raw_max = raw_range_from_physical(signal)
+	value_member_type = "int" if signal.choices else "double"
 	return (
-		("Pv", "double", physical_start_value(signal), signal.minimum, signal.maximum, True),
+		("Pv", value_member_type, physical_start_value(signal), signal.minimum, signal.maximum, True),
 		("Rv", "int", signal.start_raw, raw_min, raw_max, True),
 		("Factor", "double", signal.factor, None, None, False),
 		("Offset", "double", signal.offset, None, None, False),

--- a/xodr_converter/dbc_to_vsysvar.py
+++ b/xodr_converter/dbc_to_vsysvar.py
@@ -47,25 +47,48 @@ def read_text_file(path: str, encoding: Optional[str] = None) -> str:
 	with open(path, "rb") as fh:
 		data = fh.read()
 
-	encodings = []
-	if encoding:
-		encodings.append(encoding)
-	encodings.extend(["utf-8-sig", "utf-8", "gb18030", "gbk", "cp936", "cp1252"])
+	return decode_dbc_bytes(data, preferred_encoding=encoding)
 
-	tried = set()
-	for candidate in encodings:
-		normalized = candidate.lower()
-		if normalized in tried:
-			continue
-		tried.add(normalized)
-		try:
-			return data.decode(candidate)
-		except UnicodeDecodeError:
-			continue
 
-	if encoding:
-		return data.decode(encoding, errors="replace")
-	return data.decode("utf-8", errors="replace")
+def decode_dbc_bytes(data: bytes, preferred_encoding: Optional[str] = None) -> str:
+	candidates = unique_encodings(
+		[preferred_encoding, "utf-8-sig", "utf-8", "gb18030", "gbk", "cp936", "cp1252"]
+	)
+	best_text = ""
+	best_score: Optional[Tuple[int, int, int]] = None
+
+	for index, candidate in enumerate(candidates):
+		text = data.decode(candidate, errors="replace")
+		score = score_decoded_text(text, preferred=candidate == preferred_encoding, order=index)
+		if best_score is None or score > best_score:
+			best_text = text
+			best_score = score
+
+	return best_text
+
+
+def unique_encodings(encodings: Sequence[Optional[str]]) -> List[str]:
+	unique: List[str] = []
+	seen = set()
+	for encoding in encodings:
+		if not encoding:
+			continue
+		normalized = encoding.lower()
+		if normalized in seen:
+			continue
+		seen.add(normalized)
+		unique.append(encoding)
+	return unique
+
+
+def score_decoded_text(text: str, preferred: bool, order: int) -> Tuple[int, int, int]:
+	replacement_count = text.count("\ufffd")
+	cjk_count = sum(1 for char in text if "\u4e00" <= char <= "\u9fff")
+	mojibake_count = sum(1 for char in text if char in "ÃÂÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝÞß")
+	score = cjk_count * 20 - replacement_count * 100 - mojibake_count * 10
+	if preferred:
+		score += 5
+	return score, -replacement_count, -order
 
 
 def parse_dbc_file(path: str, encoding: Optional[str] = None) -> DbcDatabase:

--- a/xodr_converter/dbc_to_vsysvar.py
+++ b/xodr_converter/dbc_to_vsysvar.py
@@ -253,19 +253,20 @@ def physical_start_value(signal: DbcSignal) -> Decimal:
 	return signal.start_raw * signal.factor + signal.offset
 
 
-def raw_range_from_physical(signal: DbcSignal) -> Tuple[Decimal, Decimal]:
+def raw_range_from_physical(signal: DbcSignal) -> Tuple[Optional[Decimal], Optional[Decimal]]:
 	if signal.factor == 0:
-		return Decimal("0"), Decimal("0")
+		return None, None
 
 	raw_a = (signal.minimum - signal.offset) / signal.factor
 	raw_b = (signal.maximum - signal.offset) / signal.factor
 	low = min(raw_a, raw_b)
 	high = max(raw_a, raw_b)
 
-	return (
-		low.to_integral_value(rounding=ROUND_CEILING),
-		high.to_integral_value(rounding=ROUND_FLOOR),
-	)
+	raw_min = low.to_integral_value(rounding=ROUND_CEILING)
+	raw_max = high.to_integral_value(rounding=ROUND_FLOOR)
+	if raw_min > raw_max:
+		return None, None
+	return raw_min, raw_max
 
 
 def build_vsysvar_tree(dbc_specs: Sequence[Tuple[str, DbcDatabase]]) -> ET.ElementTree:

--- a/xodr_converter/dbc_to_vsysvar.py
+++ b/xodr_converter/dbc_to_vsysvar.py
@@ -492,9 +492,11 @@ def add_message_struct_and_variable(
 			if include_value_table and normal_choices:
 				add_value_table(member_element, f"{signal.name}Vt", normal_choices)
 			bitcount += 64
+		add_has_special_value_member(struct_element, signal)
+		bitcount += 64
 		if special_choices:
-			add_special_value_members(struct_element, signal, special_choices)
-			bitcount += 128
+			add_special_value_member(struct_element, signal, special_choices)
+			bitcount += 64
 
 	ET.SubElement(
 		namespace_element,
@@ -515,9 +517,7 @@ def add_message_struct_and_variable(
 	)
 
 
-def add_special_value_members(
-	struct_element: ET.Element, signal: DbcSignal, special_choices: List[ValueTableEntry]
-) -> None:
+def add_has_special_value_member(struct_element: ET.Element, signal: DbcSignal) -> None:
 	has_special_member = ET.SubElement(
 		struct_element,
 		"structMember",
@@ -540,6 +540,10 @@ def add_special_value_members(
 		],
 	)
 
+
+def add_special_value_member(
+	struct_element: ET.Element, signal: DbcSignal, special_choices: List[ValueTableEntry]
+) -> None:
 	special_value_member = ET.SubElement(
 		struct_element,
 		"structMember",

--- a/xodr_converter/dbc_to_vsysvar.py
+++ b/xodr_converter/dbc_to_vsysvar.py
@@ -759,6 +759,7 @@ def struct_member_attrs(
 	max_value: Optional[Decimal],
 	bitcount: int = 64,
 ) -> Dict[str, str]:
+	actual_bitcount = 32 if member_type == "int" else bitcount
 	attrs = {
 		"relativeOffset": "0",
 		"byteOrder": "0",
@@ -766,7 +767,7 @@ def struct_member_attrs(
 		"isHidden": "False",
 		"name": name,
 		"comment": comment,
-		"bitcount": str(bitcount),
+		"bitcount": str(actual_bitcount),
 		"isSigned": "true" if is_signed else "false",
 		"encoding": "65001",
 		"type": member_type,

--- a/xodr_converter/dbc_to_vsysvar.py
+++ b/xodr_converter/dbc_to_vsysvar.py
@@ -47,14 +47,24 @@ def read_text_file(path: str, encoding: Optional[str] = None) -> str:
 	with open(path, "rb") as fh:
 		data = fh.read()
 
+	encodings = []
 	if encoding:
-		return data.decode(encoding)
+		encodings.append(encoding)
+	encodings.extend(["utf-8-sig", "utf-8", "gb18030", "gbk", "cp936", "cp1252"])
 
-	for encoding in ("utf-8-sig", "utf-8", "gb18030", "cp1252"):
+	tried = set()
+	for candidate in encodings:
+		normalized = candidate.lower()
+		if normalized in tried:
+			continue
+		tried.add(normalized)
 		try:
-			return data.decode(encoding)
+			return data.decode(candidate)
 		except UnicodeDecodeError:
 			continue
+
+	if encoding:
+		return data.decode(encoding, errors="replace")
 	return data.decode("utf-8", errors="replace")
 
 

--- a/xodr_converter/dbc_to_vsysvar.py
+++ b/xodr_converter/dbc_to_vsysvar.py
@@ -79,7 +79,7 @@ def read_text_file(path: str, encoding: Optional[str] = None) -> str:
 
 def decode_dbc_bytes(data: bytes, preferred_encoding: Optional[str] = None) -> str:
 	encoding = preferred_encoding or "utf-8-sig"
-	return data.decode(encoding)
+	return data.decode(encoding, errors="replace")
 
 
 def parse_dbc_file(path: str, encoding: Optional[str] = None) -> DbcDatabase:

--- a/xodr_converter/dbc_to_vsysvar.py
+++ b/xodr_converter/dbc_to_vsysvar.py
@@ -18,6 +18,15 @@ class ValueTableEntry:
 
 
 @dataclass
+class MessageInfo:
+	send_type_value: Decimal
+	send_type_name: str
+	send_type_choices: List[ValueTableEntry]
+	cycle_time: Decimal
+	cycle_time_max: Optional[Decimal] = None
+
+
+@dataclass
 class DbcSignal:
 	name: str
 	start_bit: int
@@ -41,6 +50,7 @@ class DbcMessage:
 	name: str
 	dlc: int
 	sender: str
+	info: MessageInfo
 	signals: List[DbcSignal] = field(default_factory=list)
 
 
@@ -83,7 +93,27 @@ def convert_cantools_message(message) -> DbcMessage:
 		name=message.name,
 		dlc=message.length,
 		sender=senders[0] if senders else "",
+		info=convert_cantools_message_info(message),
 		signals=[convert_cantools_signal(signal) for signal in message.signals],
+	)
+
+
+def convert_cantools_message_info(message) -> MessageInfo:
+	send_type_choices = get_attribute_choices(message, "GenMsgSendType") or default_send_type_choices()
+	send_type_value = get_message_attribute_value(message, "GenMsgSendType")
+	if send_type_value is None:
+		send_type_value = get_attribute_default_value(message, "GenMsgSendType")
+	send_type_index = resolve_send_type_index(send_type_value, send_type_choices)
+	cycle_time = get_message_attribute_value(message, "GenMsgCycleTime")
+	if cycle_time is None:
+		cycle_time = get_attribute_default_value(message, "GenMsgCycleTime")
+
+	return MessageInfo(
+		send_type_value=send_type_index,
+		send_type_name=choice_name_by_value(send_type_choices, send_type_index),
+		send_type_choices=send_type_choices,
+		cycle_time=to_decimal(cycle_time, Decimal("0")),
+		cycle_time_max=get_attribute_maximum(message, "GenMsgCycleTime"),
 	)
 
 
@@ -121,9 +151,69 @@ def convert_cantools_choices(choices) -> List[ValueTableEntry]:
 	return sorted(entries, key=lambda entry: entry.value)
 
 
+def default_send_type_choices() -> List[ValueTableEntry]:
+	return [
+		ValueTableEntry(Decimal(index), name)
+		for index, name in enumerate(["Cycle", "Event", "IfActive", "CE", "CA", "NoMsgSendType"])
+	]
+
+
+def get_message_attribute_value(message, name: str):
+	attribute = getattr(message.dbc, "_attributes", {}).get(name) if message.dbc else None
+	return getattr(attribute, "value", None) if attribute is not None else None
+
+
+def get_attribute_definition(message, name: str):
+	return getattr(message.dbc, "_attribute_definitions", {}).get(name) if message.dbc else None
+
+
+def get_attribute_default_value(message, name: str):
+	definition = get_attribute_definition(message, name)
+	return getattr(definition, "default_value", None) if definition is not None else None
+
+
+def get_attribute_maximum(message, name: str) -> Optional[Decimal]:
+	definition = get_attribute_definition(message, name)
+	if definition is None:
+		return None
+	return to_optional_decimal(getattr(definition, "maximum", None))
+
+
+def get_attribute_choices(message, name: str) -> List[ValueTableEntry]:
+	definition = get_attribute_definition(message, name)
+	choices = getattr(definition, "choices", None) if definition is not None else None
+	if not choices:
+		return []
+	return [ValueTableEntry(Decimal(index), str(choice)) for index, choice in enumerate(choices)]
+
+
+def resolve_send_type_index(value, choices: List[ValueTableEntry]) -> Decimal:
+	if value is None:
+		value = "Cycle"
+	if isinstance(value, str):
+		for entry in choices:
+			if entry.description == value:
+				return entry.value
+		return Decimal("0")
+	return to_decimal(value, Decimal("0"))
+
+
+def choice_name_by_value(choices: List[ValueTableEntry], value: Decimal) -> str:
+	for entry in choices:
+		if entry.value == value:
+			return entry.description
+	return "Cycle"
+
+
 def to_decimal(value, default: Decimal) -> Decimal:
 	if value is None:
 		return default
+	return Decimal(str(value))
+
+
+def to_optional_decimal(value) -> Optional[Decimal]:
+	if value is None:
+		return None
 	return Decimal(str(value))
 
 
@@ -163,6 +253,7 @@ def build_vsysvar_tree(dbc_specs: Sequence[Tuple[str, DbcDatabase]]) -> ET.Eleme
 	for namespace_name, database in dbc_specs:
 		namespace_element = ET.SubElement(root_namespace, "namespace", namespace_attrs(namespace_name))
 		for message in database.messages:
+			add_message_info_struct_and_variable(namespace_element, namespace_name, message)
 			add_message_struct_and_variable(namespace_element, namespace_name, message)
 
 	tree = ET.ElementTree(root)
@@ -172,6 +263,89 @@ def build_vsysvar_tree(dbc_specs: Sequence[Tuple[str, DbcDatabase]]) -> ET.Eleme
 
 def namespace_attrs(name: str) -> Dict[str, str]:
 	return {"name": name, "comment": "", "interface": ""}
+
+
+def add_message_info_struct_and_variable(
+	namespace_element: ET.Element, namespace_name: str, message: DbcMessage
+) -> None:
+	struct_name = f"{message.name.lower()}_info"
+	struct_element = ET.SubElement(
+		namespace_element,
+		"struct",
+		{
+			"name": struct_name,
+			"isUnion": "False",
+			"definedBinaryLayout": "False",
+			"comment": "",
+		},
+	)
+
+	member_count = 0
+	for name, start_value, min_value, max_value, choices in message_info_member_specs(message):
+		member_element = ET.SubElement(
+			struct_element,
+			"structMember",
+			struct_member_attrs(
+				name=name,
+				comment="",
+				is_signed=False,
+				member_type="int",
+				start_value=start_value,
+				min_value=min_value,
+				max_value=max_value,
+				bitcount=32,
+			),
+		)
+		if choices:
+			add_value_table(member_element, f"{name}Vt", choices)
+		member_count += 1
+
+	ET.SubElement(
+		namespace_element,
+		"variable",
+		{
+			"anlyzLocal": "2",
+			"readOnly": "false",
+			"valueSequence": "false",
+			"unit": "",
+			"name": f"{message.name}_Info",
+			"comment": "",
+			"bitcount": str(member_count * 32),
+			"isSigned": "true",
+			"encoding": "65001",
+			"type": "struct",
+			"structDefinition": f"{namespace_name}::{struct_name}",
+		},
+	)
+
+
+def message_info_member_specs(
+	message: DbcMessage,
+) -> Iterable[Tuple[str, Decimal, Optional[Decimal], Optional[Decimal], List[ValueTableEntry]]]:
+	prefix = message.name
+	send_type_max = Decimal(len(message.info.send_type_choices) - 1)
+	specs = [
+		(f"{prefix}_MsgOn", Decimal("1"), Decimal("0"), Decimal("1"), []),
+		(f"{prefix}_MsgOff", Decimal("0"), Decimal("0"), Decimal("1"), []),
+		(
+			f"{prefix}_MsgSendType",
+			message.info.send_type_value,
+			Decimal("0"),
+			send_type_max,
+			message.info.send_type_choices,
+		),
+	]
+	if message.info.send_type_name in {"Cycle", "CE", "CA"}:
+		specs.append(
+			(
+				f"{prefix}_MsgCycleTime",
+				message.info.cycle_time,
+				Decimal("0"),
+				message.info.cycle_time_max,
+				[],
+			)
+		)
+	return specs
 
 
 def add_message_struct_and_variable(
@@ -206,7 +380,7 @@ def add_message_struct_and_variable(
 				),
 			)
 			if include_value_table and signal.choices:
-				add_value_table(member_element, signal)
+				add_value_table(member_element, f"{signal.name}Vt", signal.choices)
 			bitcount += 64
 
 	ET.SubElement(
@@ -249,6 +423,7 @@ def struct_member_attrs(
 	start_value: Decimal,
 	min_value: Optional[Decimal],
 	max_value: Optional[Decimal],
+	bitcount: int = 64,
 ) -> Dict[str, str]:
 	attrs = {
 		"relativeOffset": "0",
@@ -257,7 +432,7 @@ def struct_member_attrs(
 		"isHidden": "False",
 		"name": name,
 		"comment": comment,
-		"bitcount": "64",
+		"bitcount": str(bitcount),
 		"isSigned": "true" if is_signed else "false",
 		"encoding": "65001",
 		"type": member_type,
@@ -270,16 +445,18 @@ def struct_member_attrs(
 	return attrs
 
 
-def add_value_table(member_element: ET.Element, signal: DbcSignal) -> None:
+def add_value_table(
+	member_element: ET.Element, value_table_name: str, entries: List[ValueTableEntry]
+) -> None:
 	value_table = ET.SubElement(
 		member_element,
 		"valuetable",
 		{
-			"name": signal.name,
+			"name": value_table_name,
 			"definesMinMax": "false",
 		},
 	)
-	for entry in signal.choices:
+	for entry in entries:
 		value = decimal_to_text(entry.value)
 		ET.SubElement(
 			value_table,

--- a/xodr_converter/dbc_to_vsysvar.py
+++ b/xodr_converter/dbc_to_vsysvar.py
@@ -513,12 +513,25 @@ def signal_member_specs(
 	signal: DbcSignal,
 ) -> Iterable[Tuple[str, str, Decimal, Optional[Decimal], Optional[Decimal], bool]]:
 	raw_min, raw_max = raw_range_from_physical(signal)
-	value_member_type = "int" if signal.choices else "double"
+	value_member_type = "int" if should_use_int_for_physical_value(signal) else "double"
 	return (
 		("Pv", value_member_type, physical_start_value(signal), signal.minimum, signal.maximum, True),
 		("Rv", "int", signal.start_raw, raw_min, raw_max, True),
 		("Factor", "double", signal.factor, None, None, False),
 		("Offset", "double", signal.offset, None, None, False),
+	)
+
+
+def should_use_int_for_physical_value(signal: DbcSignal) -> bool:
+	if signal.choices:
+		return True
+	if signal.offset != 0:
+		return False
+	if signal.factor != signal.factor.to_integral_value():
+		return False
+	return (
+		INT_MIN_VALUE <= signal.minimum <= INT_MAX_VALUE
+		and INT_MIN_VALUE <= signal.maximum <= INT_MAX_VALUE
 	)
 
 

--- a/xodr_converter/dbc_to_vsysvar.py
+++ b/xodr_converter/dbc_to_vsysvar.py
@@ -51,7 +51,6 @@ class DbcSignal:
 	start_raw: Decimal = Decimal("0")
 	choices: List[ValueTableEntry] = field(default_factory=list)
 	inactive_raw: Optional[Decimal] = None
-	multiplexer_ids: List[int] = field(default_factory=list)
 
 
 @dataclass
@@ -158,7 +157,6 @@ def convert_cantools_signal(signal) -> DbcSignal:
 		start_raw=to_decimal(signal.raw_initial, Decimal("0")),
 		choices=convert_cantools_choices(signal.choices),
 		inactive_raw=to_optional_decimal(get_signal_attribute_value(signal, "GenSigInactiveValue")),
-		multiplexer_ids=list(signal.multiplexer_ids or []),
 	)
 
 
@@ -482,7 +480,6 @@ def add_message_struct_and_variable(
 
 	bitcount = 0
 	for signal in message.signals:
-		member_base_name = signal_member_base_name(signal)
 		normal_choices = normal_value_table_choices(signal)
 		special_choices = special_value_table_choices(signal)
 		for suffix, member_type, start_value, min_value, max_value, include_value_table in signal_member_specs(signal):
@@ -490,7 +487,7 @@ def add_message_struct_and_variable(
 				struct_element,
 				"structMember",
 				struct_member_attrs(
-					name=f"{member_base_name}_{suffix}",
+					name=f"{signal.name}_{suffix}",
 					comment=signal.comment,
 					is_signed=signal.is_signed,
 					member_type=member_type,
@@ -500,7 +497,7 @@ def add_message_struct_and_variable(
 				),
 			)
 			if include_value_table and normal_choices:
-				add_value_table(member_element, f"{member_base_name}Vt", normal_choices)
+				add_value_table(member_element, f"{signal.name}Vt", normal_choices)
 			bitcount += 64
 		add_has_special_value_member(struct_element, signal, has_special_value=bool(special_choices))
 		bitcount += 64
@@ -534,22 +531,14 @@ def add_message_struct_and_variable(
 	)
 
 
-def signal_member_base_name(signal: DbcSignal) -> str:
-	if not signal.multiplexer_ids:
-		return signal.name
-	mux_suffix = "_".join(f"m{mux_id}" for mux_id in signal.multiplexer_ids)
-	return f"{signal.name}_{mux_suffix}"
-
-
 def add_has_special_value_member(
 	struct_element: ET.Element, signal: DbcSignal, has_special_value: bool
 ) -> None:
-	member_base_name = signal_member_base_name(signal)
 	has_special_member = ET.SubElement(
 		struct_element,
 		"structMember",
 		struct_member_attrs(
-			name=f"{member_base_name}_has_special_value",
+			name=f"{signal.name}_has_special_value",
 			comment="",
 			is_signed=False,
 			member_type="int",
@@ -560,7 +549,7 @@ def add_has_special_value_member(
 	)
 	add_value_table(
 		has_special_member,
-		f"{member_base_name}_has_special_valueVt",
+		f"{signal.name}_has_special_valueVt",
 		[
 			ValueTableEntry(Decimal("0"), "no"),
 			ValueTableEntry(Decimal("1"), "yes"),
@@ -569,12 +558,11 @@ def add_has_special_value_member(
 
 
 def add_use_special_value_member(struct_element: ET.Element, signal: DbcSignal) -> None:
-	member_base_name = signal_member_base_name(signal)
 	use_special_member = ET.SubElement(
 		struct_element,
 		"structMember",
 		struct_member_attrs(
-			name=f"{member_base_name}_use_special_value",
+			name=f"{signal.name}_use_special_value",
 			comment="",
 			is_signed=False,
 			member_type="int",
@@ -585,7 +573,7 @@ def add_use_special_value_member(struct_element: ET.Element, signal: DbcSignal) 
 	)
 	add_value_table(
 		use_special_member,
-		f"{member_base_name}_use_special_valueVt",
+		f"{signal.name}_use_special_valueVt",
 		[
 			ValueTableEntry(Decimal("0"), "not use"),
 			ValueTableEntry(Decimal("1"), "use"),
@@ -596,12 +584,11 @@ def add_use_special_value_member(struct_element: ET.Element, signal: DbcSignal) 
 def add_special_value_member(
 	struct_element: ET.Element, signal: DbcSignal, special_choices: List[ValueTableEntry]
 ) -> None:
-	member_base_name = signal_member_base_name(signal)
 	special_value_member = ET.SubElement(
 		struct_element,
 		"structMember",
 		struct_member_attrs(
-			name=f"{member_base_name}_special_value",
+			name=f"{signal.name}_special_value",
 			comment="",
 			is_signed=signal.is_signed,
 			member_type="int",
@@ -610,16 +597,15 @@ def add_special_value_member(
 			max_value=None,
 		),
 	)
-	add_value_table(special_value_member, f"{member_base_name}_special_valueVt", special_choices)
+	add_value_table(special_value_member, f"{signal.name}_special_valueVt", special_choices)
 
 
 def add_has_inactive_value_member(struct_element: ET.Element, signal: DbcSignal) -> None:
-	member_base_name = signal_member_base_name(signal)
 	has_inactive_member = ET.SubElement(
 		struct_element,
 		"structMember",
 		struct_member_attrs(
-			name=f"{member_base_name}_has_inactive_value",
+			name=f"{signal.name}_has_inactive_value",
 			comment="",
 			is_signed=False,
 			member_type="int",
@@ -630,7 +616,7 @@ def add_has_inactive_value_member(struct_element: ET.Element, signal: DbcSignal)
 	)
 	add_value_table(
 		has_inactive_member,
-		f"{member_base_name}_has_inactive_valueVt",
+		f"{signal.name}_has_inactive_valueVt",
 		[
 			ValueTableEntry(Decimal("0"), "no"),
 			ValueTableEntry(Decimal("1"), "yes"),
@@ -639,12 +625,11 @@ def add_has_inactive_value_member(struct_element: ET.Element, signal: DbcSignal)
 
 
 def add_use_inactive_value_member(struct_element: ET.Element, signal: DbcSignal) -> None:
-	member_base_name = signal_member_base_name(signal)
 	use_inactive_member = ET.SubElement(
 		struct_element,
 		"structMember",
 		struct_member_attrs(
-			name=f"{member_base_name}_use_inactive_value",
+			name=f"{signal.name}_use_inactive_value",
 			comment="",
 			is_signed=False,
 			member_type="int",
@@ -655,7 +640,7 @@ def add_use_inactive_value_member(struct_element: ET.Element, signal: DbcSignal)
 	)
 	add_value_table(
 		use_inactive_member,
-		f"{member_base_name}_use_inactive_valueVt",
+		f"{signal.name}_use_inactive_valueVt",
 		[
 			ValueTableEntry(Decimal("0"), "not use"),
 			ValueTableEntry(Decimal("1"), "use"),
@@ -664,13 +649,12 @@ def add_use_inactive_value_member(struct_element: ET.Element, signal: DbcSignal)
 
 
 def add_inactive_value_member(struct_element: ET.Element, signal: DbcSignal) -> None:
-	member_base_name = signal_member_base_name(signal)
 	inactive_raw = signal.inactive_raw if signal.inactive_raw is not None else Decimal("0")
 	inactive_value_member = ET.SubElement(
 		struct_element,
 		"structMember",
 		struct_member_attrs(
-			name=f"{member_base_name}_inactive_value",
+			name=f"{signal.name}_inactive_value",
 			comment="",
 			is_signed=signal.is_signed,
 			member_type="int",
@@ -681,7 +665,7 @@ def add_inactive_value_member(struct_element: ET.Element, signal: DbcSignal) -> 
 	)
 	add_value_table(
 		inactive_value_member,
-		f"{member_base_name}_inactive_valueVt",
+		f"{signal.name}_inactive_valueVt",
 		[ValueTableEntry(inactive_raw, "inactive")],
 	)
 

--- a/xodr_converter/dbc_to_vsysvar.py
+++ b/xodr_converter/dbc_to_vsysvar.py
@@ -24,6 +24,10 @@ class MessageInfo:
 	send_type_choices: List[ValueTableEntry]
 	cycle_time: Decimal
 	cycle_time_max: Optional[Decimal] = None
+	cycle_time_fast: Decimal = Decimal("0")
+	cycle_time_fast_max: Optional[Decimal] = None
+	nr_of_repetition: Decimal = Decimal("0")
+	nr_of_repetition_max: Optional[Decimal] = None
 
 
 @dataclass
@@ -111,6 +115,12 @@ def convert_cantools_message_info(message) -> MessageInfo:
 	cycle_time = get_message_attribute_value(message, "GenMsgCycleTime")
 	if cycle_time is None:
 		cycle_time = get_attribute_default_value(message, "GenMsgCycleTime")
+	cycle_time_fast = get_message_attribute_value(message, "GenMsgCycleTimeFast")
+	if cycle_time_fast is None:
+		cycle_time_fast = get_attribute_default_value(message, "GenMsgCycleTimeFast")
+	nr_of_repetition = get_message_attribute_value(message, "GenMsgNrOfRepetition")
+	if nr_of_repetition is None:
+		nr_of_repetition = get_attribute_default_value(message, "GenMsgNrOfRepetition")
 
 	return MessageInfo(
 		send_type_value=send_type_index,
@@ -118,6 +128,10 @@ def convert_cantools_message_info(message) -> MessageInfo:
 		send_type_choices=send_type_choices,
 		cycle_time=to_decimal(cycle_time, Decimal("0")),
 		cycle_time_max=get_attribute_maximum(message, "GenMsgCycleTime"),
+		cycle_time_fast=to_decimal(cycle_time_fast, Decimal("0")),
+		cycle_time_fast_max=get_attribute_maximum(message, "GenMsgCycleTimeFast"),
+		nr_of_repetition=to_decimal(nr_of_repetition, Decimal("0")),
+		nr_of_repetition_max=get_attribute_maximum(message, "GenMsgNrOfRepetition"),
 	)
 
 
@@ -399,6 +413,25 @@ def message_info_member_specs(
 				message.info.cycle_time_max,
 				[],
 			)
+		)
+	if message.info.send_type_name == "CE":
+		specs.extend(
+			[
+				(
+					f"{prefix}_MsgCycleTimeFast",
+					message.info.cycle_time_fast,
+					Decimal("0"),
+					message.info.cycle_time_fast_max,
+					[],
+				),
+				(
+					f"{prefix}_MsgNrOfRepetition",
+					message.info.nr_of_repetition,
+					Decimal("0"),
+					message.info.nr_of_repetition_max,
+					[],
+				),
+			]
 		)
 	return specs
 

--- a/xodr_converter/dbc_to_vsysvar.py
+++ b/xodr_converter/dbc_to_vsysvar.py
@@ -42,10 +42,13 @@ class DbcDatabase:
 	messages: List[DbcMessage]
 
 
-def read_text_file(path: str) -> str:
+def read_text_file(path: str, encoding: Optional[str] = None) -> str:
 	"""Read DBC text while tolerating common Chinese and UTF encodings."""
 	with open(path, "rb") as fh:
 		data = fh.read()
+
+	if encoding:
+		return data.decode(encoding)
 
 	for encoding in ("utf-8-sig", "utf-8", "gb18030", "cp1252"):
 		try:
@@ -55,8 +58,8 @@ def read_text_file(path: str) -> str:
 	return data.decode("utf-8", errors="replace")
 
 
-def parse_dbc_file(path: str) -> DbcDatabase:
-	return parse_dbc_text(read_text_file(path))
+def parse_dbc_file(path: str, encoding: Optional[str] = None) -> DbcDatabase:
+	return parse_dbc_text(read_text_file(path, encoding=encoding))
 
 
 def parse_dbc_text(text: str) -> DbcDatabase:
@@ -272,8 +275,10 @@ def derive_namespace_from_path(path: str) -> str:
 	return name or "DBC"
 
 
-def convert_dbc_files_to_vsysvar(dbc_specs: Sequence[Tuple[str, str]], output_path: str) -> None:
-	databases = [(namespace, parse_dbc_file(path)) for namespace, path in dbc_specs]
+def convert_dbc_files_to_vsysvar(
+	dbc_specs: Sequence[Tuple[str, str]], output_path: str, encoding: Optional[str] = None
+) -> None:
+	databases = [(namespace, parse_dbc_file(path, encoding=encoding)) for namespace, path in dbc_specs]
 	tree = build_vsysvar_tree(databases)
 	write_vsysvar_file(tree, output_path)
 
@@ -289,9 +294,17 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
 		help="DBC input. Use Namespace=path/to/file.dbc; may be repeated.",
 	)
 	parser.add_argument("--out", required=True, help="Output .vsysvar path")
+	parser.add_argument(
+		"--dbc-encoding",
+		help="Optional DBC file encoding, for example gb18030 for GBK/ANSI Chinese DBC files.",
+	)
 	args = parser.parse_args(argv)
 
-	convert_dbc_files_to_vsysvar([parse_dbc_spec(spec) for spec in args.dbc], args.out)
+	convert_dbc_files_to_vsysvar(
+		[parse_dbc_spec(spec) for spec in args.dbc],
+		args.out,
+		encoding=args.dbc_encoding,
+	)
 
 
 if __name__ == "__main__":

--- a/xodr_converter/dbc_to_vsysvar.py
+++ b/xodr_converter/dbc_to_vsysvar.py
@@ -4,32 +4,11 @@ import argparse
 import os
 import re
 from dataclasses import dataclass, field
-from decimal import Decimal, InvalidOperation, ROUND_CEILING, ROUND_FLOOR
+from decimal import Decimal, ROUND_CEILING, ROUND_FLOOR
 from typing import Dict, Iterable, List, Optional, Sequence, Tuple
 from xml.etree import ElementTree as ET
 
-
-NUMBER_RE = r"[-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][-+]?\d+)?"
-
-MESSAGE_RE = re.compile(
-	r"^BO_\s+(?P<id>\d+)\s+(?P<name>\S+)\s*:\s+(?P<dlc>\d+)\s+(?P<sender>\S+)"
-)
-SIGNAL_RE = re.compile(
-	r"^SG_\s+(?P<name>\S+)(?:\s+\S+)?\s*:\s*"
-	r"(?P<start>\d+)\|(?P<length>\d+)@(?P<byte_order>[01])(?P<sign>[+-])\s*"
-	r"\((?P<factor>{number}),(?P<offset>{number})\)\s*"
-	r"\[(?P<minimum>{number})\|(?P<maximum>{number})\]\s*"
-	r"\"(?P<unit>(?:\\.|[^\"])*)\"\s*(?P<receivers>.*)$".format(number=NUMBER_RE)
-)
-COMMENT_RE = re.compile(
-	r"^CM_\s+SG_\s+(?P<message_id>\d+)\s+(?P<signal_name>\S+)\s+\"(?P<comment>(?:\\.|[^\"])*)\"\s*;"
-)
-START_VALUE_RE = re.compile(
-	r"^BA_\s+\"GenSigStartValue\"\s+SG_\s+"
-	r"(?P<message_id>\d+)\s+(?P<signal_name>\S+)\s+(?P<value>{number})\s*;".format(
-		number=NUMBER_RE
-	)
-)
+import cantools
 
 
 @dataclass
@@ -81,91 +60,48 @@ def parse_dbc_file(path: str) -> DbcDatabase:
 
 
 def parse_dbc_text(text: str) -> DbcDatabase:
-	messages: List[DbcMessage] = []
-	signal_by_key: Dict[Tuple[int, str], DbcSignal] = {}
-	comments: Dict[Tuple[int, str], str] = {}
-	start_values: Dict[Tuple[int, str], Decimal] = {}
-	current_message: Optional[DbcMessage] = None
-
-	for raw_line in text.splitlines():
-		line = raw_line.strip()
-		if not line:
-			continue
-
-		message_match = MESSAGE_RE.match(line)
-		if message_match:
-			current_message = DbcMessage(
-				frame_id=int(message_match.group("id")),
-				name=message_match.group("name"),
-				dlc=int(message_match.group("dlc")),
-				sender=message_match.group("sender"),
-			)
-			messages.append(current_message)
-			continue
-
-		signal_match = SIGNAL_RE.match(line)
-		if signal_match and current_message is not None:
-			signal = DbcSignal(
-				name=signal_match.group("name"),
-				start_bit=int(signal_match.group("start")),
-				length=int(signal_match.group("length")),
-				byte_order=int(signal_match.group("byte_order")),
-				is_signed=signal_match.group("sign") == "-",
-				factor=parse_decimal(signal_match.group("factor")),
-				offset=parse_decimal(signal_match.group("offset")),
-				minimum=parse_decimal(signal_match.group("minimum")),
-				maximum=parse_decimal(signal_match.group("maximum")),
-				unit=unescape_dbc_string(signal_match.group("unit")),
-				receivers=parse_receivers(signal_match.group("receivers")),
-			)
-			current_message.signals.append(signal)
-			signal_by_key[(current_message.frame_id, signal.name)] = signal
-			continue
-
-		comment_match = COMMENT_RE.match(line)
-		if comment_match:
-			key = (int(comment_match.group("message_id")), comment_match.group("signal_name"))
-			comments[key] = unescape_dbc_string(comment_match.group("comment"))
-			continue
-
-		start_value_match = START_VALUE_RE.match(line)
-		if start_value_match:
-			key = (
-				int(start_value_match.group("message_id")),
-				start_value_match.group("signal_name"),
-			)
-			start_values[key] = parse_decimal(start_value_match.group("value"))
-			continue
-
-	for key, comment in comments.items():
-		signal = signal_by_key.get(key)
-		if signal is not None:
-			signal.comment = comment
-
-	for key, start_value in start_values.items():
-		signal = signal_by_key.get(key)
-		if signal is not None:
-			signal.start_raw = start_value
-
-	return DbcDatabase(messages=messages)
+	database = cantools.database.load_string(
+		text,
+		database_format="dbc",
+		strict=False,
+		sort_signals=None,
+	)
+	return DbcDatabase(messages=[convert_cantools_message(message) for message in database.messages])
 
 
-def parse_decimal(value: str) -> Decimal:
-	try:
-		return Decimal(value)
-	except InvalidOperation as exc:
-		raise ValueError(f"Invalid DBC numeric value: {value}") from exc
+def convert_cantools_message(message) -> DbcMessage:
+	senders = getattr(message, "senders", None) or []
+	return DbcMessage(
+		frame_id=message.frame_id,
+		name=message.name,
+		dlc=message.length,
+		sender=senders[0] if senders else "",
+		signals=[convert_cantools_signal(signal) for signal in message.signals],
+	)
 
 
-def parse_receivers(value: str) -> List[str]:
-	value = value.strip()
-	if not value:
-		return []
-	return [item.strip() for item in value.split(",") if item.strip()]
+def convert_cantools_signal(signal) -> DbcSignal:
+	return DbcSignal(
+		name=signal.name,
+		start_bit=signal.start,
+		length=signal.length,
+		byte_order=1 if signal.byte_order == "little_endian" else 0,
+		is_signed=signal.is_signed,
+		factor=to_decimal(signal.scale, Decimal("1")),
+		offset=to_decimal(signal.offset, Decimal("0")),
+		minimum=to_decimal(signal.minimum, Decimal("0")),
+		maximum=to_decimal(signal.maximum, Decimal("0")),
+		unit=signal.unit or "",
+		receivers=list(signal.receivers),
+		comment=signal.comment or "",
+		start_raw=to_decimal(signal.raw_initial, Decimal("0")),
+	)
 
 
-def unescape_dbc_string(value: str) -> str:
-	return value.replace(r"\"", '"').replace(r"\\", "\\")
+def to_decimal(value, default: Decimal) -> Decimal:
+	if value is None:
+		return default
+	return Decimal(str(value))
 
 
 def decimal_to_text(value: Decimal) -> str:

--- a/xodr_converter/dbc_to_vsysvar.py
+++ b/xodr_converter/dbc_to_vsysvar.py
@@ -473,6 +473,8 @@ def add_message_struct_and_variable(
 
 	bitcount = 0
 	for signal in message.signals:
+		normal_choices = normal_value_table_choices(signal)
+		special_choices = special_value_table_choices(signal)
 		for suffix, member_type, start_value, min_value, max_value, include_value_table in signal_member_specs(signal):
 			member_element = ET.SubElement(
 				struct_element,
@@ -487,9 +489,12 @@ def add_message_struct_and_variable(
 					max_value=max_value,
 				),
 			)
-			if include_value_table and signal.choices:
-				add_value_table(member_element, f"{signal.name}Vt", signal.choices)
+			if include_value_table and normal_choices:
+				add_value_table(member_element, f"{signal.name}Vt", normal_choices)
 			bitcount += 64
+		if special_choices:
+			add_special_value_members(struct_element, signal, special_choices)
+			bitcount += 128
 
 	ET.SubElement(
 		namespace_element,
@@ -510,6 +515,47 @@ def add_message_struct_and_variable(
 	)
 
 
+def add_special_value_members(
+	struct_element: ET.Element, signal: DbcSignal, special_choices: List[ValueTableEntry]
+) -> None:
+	has_special_member = ET.SubElement(
+		struct_element,
+		"structMember",
+		struct_member_attrs(
+			name=f"{signal.name}_has_special_value",
+			comment="",
+			is_signed=False,
+			member_type="int",
+			start_value=Decimal("0"),
+			min_value=Decimal("0"),
+			max_value=Decimal("1"),
+		),
+	)
+	add_value_table(
+		has_special_member,
+		f"{signal.name}_has_special_valueVt",
+		[
+			ValueTableEntry(Decimal("0"), "no"),
+			ValueTableEntry(Decimal("1"), "yes"),
+		],
+	)
+
+	special_value_member = ET.SubElement(
+		struct_element,
+		"structMember",
+		struct_member_attrs(
+			name=f"{signal.name}_special_value",
+			comment="",
+			is_signed=signal.is_signed,
+			member_type="int",
+			start_value=special_choices[0].value,
+			min_value=None,
+			max_value=None,
+		),
+	)
+	add_value_table(special_value_member, f"{signal.name}_special_valueVt", special_choices)
+
+
 def signal_member_specs(
 	signal: DbcSignal,
 ) -> Iterable[Tuple[str, str, Decimal, Optional[Decimal], Optional[Decimal], bool]]:
@@ -524,7 +570,7 @@ def signal_member_specs(
 
 
 def should_use_int_for_physical_value(signal: DbcSignal) -> bool:
-	if signal.choices:
+	if normal_value_table_choices(signal):
 		return True
 	if signal.offset != 0:
 		return False
@@ -538,6 +584,20 @@ def should_use_int_for_physical_value(signal: DbcSignal) -> bool:
 		INT_MIN_VALUE <= signal.minimum <= INT_MAX_VALUE
 		and INT_MIN_VALUE <= signal.maximum <= INT_MAX_VALUE
 	)
+
+
+def normal_value_table_choices(signal: DbcSignal) -> List[ValueTableEntry]:
+	raw_min, raw_max = raw_range_from_physical(signal)
+	if raw_min is None or raw_max is None:
+		return signal.choices
+	return [entry for entry in signal.choices if raw_min <= entry.value <= raw_max]
+
+
+def special_value_table_choices(signal: DbcSignal) -> List[ValueTableEntry]:
+	raw_min, raw_max = raw_range_from_physical(signal)
+	if raw_min is None or raw_max is None:
+		return []
+	return [entry for entry in signal.choices if entry.value < raw_min or entry.value > raw_max]
 
 
 def struct_member_attrs(

--- a/xodr_converter/dbc_to_vsysvar.py
+++ b/xodr_converter/dbc_to_vsysvar.py
@@ -1,0 +1,364 @@
+from __future__ import annotations
+
+import argparse
+import os
+import re
+from dataclasses import dataclass, field
+from decimal import Decimal, InvalidOperation, ROUND_CEILING, ROUND_FLOOR
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
+from xml.etree import ElementTree as ET
+
+
+NUMBER_RE = r"[-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][-+]?\d+)?"
+
+MESSAGE_RE = re.compile(
+	r"^BO_\s+(?P<id>\d+)\s+(?P<name>\S+)\s*:\s+(?P<dlc>\d+)\s+(?P<sender>\S+)"
+)
+SIGNAL_RE = re.compile(
+	r"^SG_\s+(?P<name>\S+)(?:\s+\S+)?\s*:\s*"
+	r"(?P<start>\d+)\|(?P<length>\d+)@(?P<byte_order>[01])(?P<sign>[+-])\s*"
+	r"\((?P<factor>{number}),(?P<offset>{number})\)\s*"
+	r"\[(?P<minimum>{number})\|(?P<maximum>{number})\]\s*"
+	r"\"(?P<unit>(?:\\.|[^\"])*)\"\s*(?P<receivers>.*)$".format(number=NUMBER_RE)
+)
+COMMENT_RE = re.compile(
+	r"^CM_\s+SG_\s+(?P<message_id>\d+)\s+(?P<signal_name>\S+)\s+\"(?P<comment>(?:\\.|[^\"])*)\"\s*;"
+)
+START_VALUE_RE = re.compile(
+	r"^BA_\s+\"GenSigStartValue\"\s+SG_\s+"
+	r"(?P<message_id>\d+)\s+(?P<signal_name>\S+)\s+(?P<value>{number})\s*;".format(
+		number=NUMBER_RE
+	)
+)
+
+
+@dataclass
+class DbcSignal:
+	name: str
+	start_bit: int
+	length: int
+	byte_order: int
+	is_signed: bool
+	factor: Decimal
+	offset: Decimal
+	minimum: Decimal
+	maximum: Decimal
+	unit: str
+	receivers: List[str]
+	comment: str = ""
+	start_raw: Decimal = Decimal("0")
+
+
+@dataclass
+class DbcMessage:
+	frame_id: int
+	name: str
+	dlc: int
+	sender: str
+	signals: List[DbcSignal] = field(default_factory=list)
+
+
+@dataclass
+class DbcDatabase:
+	messages: List[DbcMessage]
+
+
+def read_text_file(path: str) -> str:
+	"""Read DBC text while tolerating common Chinese and UTF encodings."""
+	with open(path, "rb") as fh:
+		data = fh.read()
+
+	for encoding in ("utf-8-sig", "utf-8", "gb18030", "cp1252"):
+		try:
+			return data.decode(encoding)
+		except UnicodeDecodeError:
+			continue
+	return data.decode("utf-8", errors="replace")
+
+
+def parse_dbc_file(path: str) -> DbcDatabase:
+	return parse_dbc_text(read_text_file(path))
+
+
+def parse_dbc_text(text: str) -> DbcDatabase:
+	messages: List[DbcMessage] = []
+	message_by_id: Dict[int, DbcMessage] = {}
+	signal_by_key: Dict[Tuple[int, str], DbcSignal] = {}
+	comments: Dict[Tuple[int, str], str] = {}
+	start_values: Dict[Tuple[int, str], Decimal] = {}
+	current_message: Optional[DbcMessage] = None
+
+	for raw_line in text.splitlines():
+		line = raw_line.strip()
+		if not line:
+			continue
+
+		message_match = MESSAGE_RE.match(line)
+		if message_match:
+			current_message = DbcMessage(
+				frame_id=int(message_match.group("id")),
+				name=message_match.group("name"),
+				dlc=int(message_match.group("dlc")),
+				sender=message_match.group("sender"),
+			)
+			messages.append(current_message)
+			message_by_id[current_message.frame_id] = current_message
+			continue
+
+		signal_match = SIGNAL_RE.match(line)
+		if signal_match and current_message is not None:
+			signal = DbcSignal(
+				name=signal_match.group("name"),
+				start_bit=int(signal_match.group("start")),
+				length=int(signal_match.group("length")),
+				byte_order=int(signal_match.group("byte_order")),
+				is_signed=signal_match.group("sign") == "-",
+				factor=parse_decimal(signal_match.group("factor")),
+				offset=parse_decimal(signal_match.group("offset")),
+				minimum=parse_decimal(signal_match.group("minimum")),
+				maximum=parse_decimal(signal_match.group("maximum")),
+				unit=unescape_dbc_string(signal_match.group("unit")),
+				receivers=parse_receivers(signal_match.group("receivers")),
+			)
+			current_message.signals.append(signal)
+			signal_by_key[(current_message.frame_id, signal.name)] = signal
+			continue
+
+		comment_match = COMMENT_RE.match(line)
+		if comment_match:
+			key = (int(comment_match.group("message_id")), comment_match.group("signal_name"))
+			comments[key] = unescape_dbc_string(comment_match.group("comment"))
+			continue
+
+		start_value_match = START_VALUE_RE.match(line)
+		if start_value_match:
+			key = (
+				int(start_value_match.group("message_id")),
+				start_value_match.group("signal_name"),
+			)
+			start_values[key] = parse_decimal(start_value_match.group("value"))
+			continue
+
+	for key, comment in comments.items():
+		signal = signal_by_key.get(key)
+		if signal is not None:
+			signal.comment = comment
+
+	for key, start_value in start_values.items():
+		signal = signal_by_key.get(key)
+		if signal is not None:
+			signal.start_raw = start_value
+
+	return DbcDatabase(messages=messages)
+
+
+def parse_decimal(value: str) -> Decimal:
+	try:
+		return Decimal(value)
+	except InvalidOperation as exc:
+		raise ValueError(f"Invalid DBC numeric value: {value}") from exc
+
+
+def parse_receivers(value: str) -> List[str]:
+	value = value.strip()
+	if not value:
+		return []
+	return [item.strip() for item in value.split(",") if item.strip()]
+
+
+def unescape_dbc_string(value: str) -> str:
+	return value.replace(r"\"", '"').replace(r"\\", "\\")
+
+
+def decimal_to_text(value: Decimal) -> str:
+	if value.is_zero():
+		return "0"
+	normalized = value.normalize()
+	text = format(normalized, "f")
+	if "." in text:
+		text = text.rstrip("0").rstrip(".")
+	return text or "0"
+
+
+def physical_start_value(signal: DbcSignal) -> Decimal:
+	return signal.start_raw * signal.factor + signal.offset
+
+
+def raw_range_from_physical(signal: DbcSignal) -> Tuple[Decimal, Decimal]:
+	if signal.factor == 0:
+		return Decimal("0"), Decimal("0")
+
+	raw_a = (signal.minimum - signal.offset) / signal.factor
+	raw_b = (signal.maximum - signal.offset) / signal.factor
+	low = min(raw_a, raw_b)
+	high = max(raw_a, raw_b)
+
+	return (
+		low.to_integral_value(rounding=ROUND_CEILING),
+		high.to_integral_value(rounding=ROUND_FLOOR),
+	)
+
+
+def build_vsysvar_tree(dbc_specs: Sequence[Tuple[str, DbcDatabase]]) -> ET.ElementTree:
+	root = ET.Element("systemvariables", {"version": "4"})
+	root_namespace = ET.SubElement(root, "namespace", namespace_attrs(""))
+
+	for namespace_name, database in dbc_specs:
+		namespace_element = ET.SubElement(root_namespace, "namespace", namespace_attrs(namespace_name))
+		for message in database.messages:
+			add_message_struct_and_variable(namespace_element, namespace_name, message)
+
+	tree = ET.ElementTree(root)
+	ET.indent(tree, space="  ")
+	return tree
+
+
+def namespace_attrs(name: str) -> Dict[str, str]:
+	return {"name": name, "comment": "", "interface": ""}
+
+
+def add_message_struct_and_variable(
+	namespace_element: ET.Element, namespace_name: str, message: DbcMessage
+) -> None:
+	struct_name = message.name.lower()
+	struct_element = ET.SubElement(
+		namespace_element,
+		"struct",
+		{
+			"name": struct_name,
+			"isUnion": "False",
+			"definedBinaryLayout": "False",
+			"comment": "",
+		},
+	)
+
+	bitcount = 0
+	for signal in message.signals:
+		for suffix, member_type, start_value, min_value, max_value in signal_member_specs(signal):
+			ET.SubElement(
+				struct_element,
+				"structMember",
+				struct_member_attrs(
+					name=f"{signal.name}_{suffix}",
+					comment=signal.comment,
+					is_signed=signal.is_signed,
+					member_type=member_type,
+					start_value=start_value,
+					min_value=min_value,
+					max_value=max_value,
+				),
+			)
+			bitcount += 64
+
+	ET.SubElement(
+		namespace_element,
+		"variable",
+		{
+			"anlyzLocal": "2",
+			"readOnly": "false",
+			"valueSequence": "false",
+			"unit": "",
+			"name": message.name,
+			"comment": "",
+			"bitcount": str(bitcount),
+			"isSigned": "true",
+			"encoding": "65001",
+			"type": "struct",
+			"structDefinition": f"{namespace_name}::{struct_name}",
+		},
+	)
+
+
+def signal_member_specs(
+	signal: DbcSignal,
+) -> Iterable[Tuple[str, str, Decimal, Optional[Decimal], Optional[Decimal]]]:
+	raw_min, raw_max = raw_range_from_physical(signal)
+	return (
+		("Pv", "double", physical_start_value(signal), signal.minimum, signal.maximum),
+		("Rv", "int", signal.start_raw, raw_min, raw_max),
+		("Factor", "double", signal.factor, None, None),
+		("Offset", "double", signal.offset, None, None),
+	)
+
+
+def struct_member_attrs(
+	name: str,
+	comment: str,
+	is_signed: bool,
+	member_type: str,
+	start_value: Decimal,
+	min_value: Optional[Decimal],
+	max_value: Optional[Decimal],
+) -> Dict[str, str]:
+	attrs = {
+		"relativeOffset": "0",
+		"byteOrder": "0",
+		"isOptional": "False",
+		"isHidden": "False",
+		"name": name,
+		"comment": comment,
+		"bitcount": "64",
+		"isSigned": "true" if is_signed else "false",
+		"encoding": "65001",
+		"type": member_type,
+		"startValue": decimal_to_text(start_value),
+	}
+	if min_value is not None:
+		attrs["minValue"] = decimal_to_text(min_value)
+	if max_value is not None:
+		attrs["maxValue"] = decimal_to_text(max_value)
+	return attrs
+
+
+def write_vsysvar_file(tree: ET.ElementTree, output_path: str) -> None:
+	output_dir = os.path.dirname(output_path)
+	if output_dir:
+		os.makedirs(output_dir, exist_ok=True)
+	tree.write(output_path, encoding="utf-8", xml_declaration=True)
+
+
+def parse_dbc_spec(spec: str) -> Tuple[str, str]:
+	if "=" in spec:
+		namespace, path = spec.split("=", 1)
+		namespace = namespace.strip()
+		path = path.strip()
+		if not namespace or not path:
+			raise ValueError(f"Invalid DBC spec '{spec}'. Expected Namespace=path/to/file.dbc")
+		return namespace, path
+
+	path = spec.strip()
+	if not path:
+		raise ValueError("DBC path must not be empty")
+	return derive_namespace_from_path(path), path
+
+
+def derive_namespace_from_path(path: str) -> str:
+	name = os.path.splitext(os.path.basename(path))[0]
+	name = re.sub(r"[^0-9A-Za-z_]+", "_", name).strip("_")
+	return name or "DBC"
+
+
+def convert_dbc_files_to_vsysvar(dbc_specs: Sequence[Tuple[str, str]], output_path: str) -> None:
+	databases = [(namespace, parse_dbc_file(path)) for namespace, path in dbc_specs]
+	tree = build_vsysvar_tree(databases)
+	write_vsysvar_file(tree, output_path)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> None:
+	parser = argparse.ArgumentParser(
+		description="Convert one or more DBC files to a CANoe .vsysvar system variable file."
+	)
+	parser.add_argument(
+		"--dbc",
+		action="append",
+		required=True,
+		help="DBC input. Use Namespace=path/to/file.dbc; may be repeated.",
+	)
+	parser.add_argument("--out", required=True, help="Output .vsysvar path")
+	args = parser.parse_args(argv)
+
+	convert_dbc_files_to_vsysvar([parse_dbc_spec(spec) for spec in args.dbc], args.out)
+
+
+if __name__ == "__main__":
+	main()

--- a/xodr_converter/dbc_to_vsysvar.py
+++ b/xodr_converter/dbc_to_vsysvar.py
@@ -502,16 +502,18 @@ def add_message_struct_and_variable(
 			bitcount += 64
 		add_has_special_value_member(struct_element, signal, has_special_value=bool(special_choices))
 		bitcount += 64
+		add_use_special_value_member(struct_element, signal)
+		bitcount += 64
 		if special_choices:
-			add_use_special_value_member(struct_element, signal)
 			add_special_value_member(struct_element, signal, special_choices)
-			bitcount += 128
+			bitcount += 64
 		add_has_inactive_value_member(struct_element, signal)
 		bitcount += 64
+		add_use_inactive_value_member(struct_element, signal)
+		bitcount += 64
 		if signal.inactive_raw is not None:
-			add_use_inactive_value_member(struct_element, signal)
 			add_inactive_value_member(struct_element, signal)
-			bitcount += 128
+			bitcount += 64
 
 	ET.SubElement(
 		namespace_element,

--- a/xodr_converter/dbc_to_vsysvar.py
+++ b/xodr_converter/dbc_to_vsysvar.py
@@ -51,28 +51,8 @@ def read_text_file(path: str, encoding: Optional[str] = None) -> str:
 
 
 def decode_dbc_bytes(data: bytes, preferred_encoding: Optional[str] = None) -> str:
-	if preferred_encoding:
-		return data.decode(preferred_encoding, errors="replace")
-
-	for candidate in unique_encodings(["utf-8-sig", "utf-8", "gb18030", "gbk", "cp936", "cp1252"]):
-		try:
-			return data.decode(candidate)
-		except UnicodeDecodeError:
-			continue
-
-	return data.decode("utf-8", errors="replace")
-
-
-def unique_encodings(encodings: Sequence[str]) -> List[str]:
-	unique: List[str] = []
-	seen = set()
-	for encoding in encodings:
-		normalized = encoding.lower()
-		if normalized in seen:
-			continue
-		seen.add(normalized)
-		unique.append(encoding)
-	return unique
+	encoding = preferred_encoding or "utf-8-sig"
+	return data.decode(encoding)
 
 
 def parse_dbc_file(path: str, encoding: Optional[str] = None) -> DbcDatabase:

--- a/xodr_converter/xvp_generator.py
+++ b/xodr_converter/xvp_generator.py
@@ -28,6 +28,8 @@ PHYSICAL_MIN_MAX_X = 787
 SPECIAL_VALUE_X = 945
 INACTIVE_VALUE_X = 1050
 MIN_MAX_FONT = "Microsoft Sans Serif, 9.25pt"
+DEFAULT_LOWER_LIMIT = "-2147483648"
+DEFAULT_UPPER_LIMIT = "2147483647"
 
 
 @dataclass
@@ -416,8 +418,8 @@ def add_radio_button(
 
 
 def alarm_general_settings(member: StructMemberInfo) -> str:
-	lower_limit = member.min_value if member.min_value != "~" else "0"
-	upper_limit = member.max_value if member.max_value != "~" else "0"
+	lower_limit = member.min_value if member.min_value != "~" else DEFAULT_LOWER_LIMIT
+	upper_limit = member.max_value if member.max_value != "~" else DEFAULT_UPPER_LIMIT
 	return f"1;{upper_limit};{lower_limit};3"
 
 

--- a/xodr_converter/xvp_generator.py
+++ b/xodr_converter/xvp_generator.py
@@ -276,20 +276,17 @@ def add_headers_and_separators(group: ET.Element, group_height: int) -> None:
 
 def add_signal_row(group: ET.Element, message: MessageInfo, row: SignalRow, y: int, row_index: int) -> None:
 	add_static_text(group, row.name, 0, y, 190, 19)
-	if row.raw_member.valuetable:
-		add_value_control(group, message, row.raw_member, RAW_VALUE_CONTROL_X, y - 2, "RawValue", row_index * 10 + 1)
-	else:
-		add_value_control(
-			group,
-			message,
-			row.raw_member,
-			RAW_VALUE_CONTROL_X,
-			y - 2,
-			"RawValue",
-			row_index * 10 + 1,
-			width=RAW_TEXT_BOX_WIDTH,
-		)
-		add_min_max_text(group, row.raw_member, RAW_MIN_MAX_X, y - 4)
+	add_value_control(
+		group,
+		message,
+		row.raw_member,
+		RAW_VALUE_CONTROL_X,
+		y - 2,
+		"RawValue",
+		row_index * 10 + 1,
+		width=RAW_TEXT_BOX_WIDTH,
+	)
+	add_min_max_text(group, row.raw_member, RAW_MIN_MAX_X, y - 4)
 	add_value_control(group, message, row.physical_member, PHYSICAL_VALUE_CONTROL_X, y - 2, "PhysicalValue", row_index * 10 + 2)
 	add_min_max_text(group, row.physical_member, PHYSICAL_MIN_MAX_X, y - 4)
 

--- a/xodr_converter/xvp_generator.py
+++ b/xodr_converter/xvp_generator.py
@@ -18,19 +18,19 @@ COMBO_BOX_TYPE = "Vector.CANalyzer.Panels.Design.ComboBoxControl, Vector.CANalyz
 RADIO_BUTTON_TYPE = "Vector.CANalyzer.Panels.Design.RadioButtonControl, Vector.CANalyzer.Panels.CommonControls, Version=18.0.150.0, Culture=neutral, PublicKeyToken=null"
 CANVAS_TYPE = "Vector.CANalyzer.Panels.Design.CanvasControl, Vector.CANalyzer.Panels.CommonControls, Version=18.0.150.0, Culture=neutral, PublicKeyToken=null"
 
-GROUP_WIDTH = 1160
-PANEL_WIDTH = 1170
+GROUP_WIDTH = 1070
+PANEL_WIDTH = 1080
 SIGNAL_RAW_SEPARATOR_X = 211
-RAW_PHYSICAL_SEPARATOR_X = 485
-PHYSICAL_SPECIAL_SEPARATOR_X = 930
+RAW_PHYSICAL_SEPARATOR_X = 531
+PHYSICAL_SPECIAL_SEPARATOR_X = 851
 RAW_VALUE_CONTROL_X = 256
-RAW_MIN_MAX_X = 385
-RAW_TEXT_BOX_WIDTH = 120
-DEFAULT_VALUE_CONTROL_WIDTH = 187
-PHYSICAL_VALUE_CONTROL_X = 533
-PHYSICAL_MIN_MAX_X = 787
-SPECIAL_VALUE_X = 945
-INACTIVE_VALUE_X = 1050
+RAW_MIN_MAX_X = 410
+RAW_TEXT_BOX_WIDTH = 140
+DEFAULT_VALUE_CONTROL_WIDTH = 140
+PHYSICAL_VALUE_CONTROL_X = 556
+PHYSICAL_MIN_MAX_X = 710
+SPECIAL_VALUE_X = 870
+INACTIVE_VALUE_X = 970
 MIN_MAX_FONT = "Microsoft Sans Serif, 9.25pt"
 DEFAULT_LOWER_LIMIT = "-2147483648"
 DEFAULT_UPPER_LIMIT = "2147483647"
@@ -264,9 +264,9 @@ def add_message_group(
 
 def add_headers_and_separators(group: ET.Element, group_height: int) -> None:
 	add_static_text(group, "Signal Name", 50, 47, 94, 19, fore_color="255, 225, 128, 48")
-	add_static_text(group, "Raw Value", 304, 47, 81, 19, fore_color="255, 225, 128, 48")
-	add_static_text(group, "Physical Value", 660, 47, 120, 19, fore_color="255, 225, 128, 48")
-	add_static_text(group, "Special Value", 995, 47, 120, 19, fore_color="255, 225, 128, 48")
+	add_static_text(group, "Raw Value", 328, 47, 81, 19, fore_color="255, 225, 128, 48")
+	add_static_text(group, "Physical Value", 635, 47, 120, 19, fore_color="255, 225, 128, 48")
+	add_static_text(group, "Special Value", 925, 47, 120, 19, fore_color="255, 225, 128, 48")
 
 	add_vertical_line(group, SIGNAL_RAW_SEPARATOR_X, 47, group_height - 38, 1)
 	add_vertical_line(group, RAW_PHYSICAL_SEPARATOR_X, 47, group_height - 38, 2)

--- a/xodr_converter/xvp_generator.py
+++ b/xodr_converter/xvp_generator.py
@@ -185,7 +185,7 @@ def build_panel_tree(messages: Sequence[MessageInfo]) -> ET.ElementTree:
 		{"Type": RUNTIME_PANEL_TYPE, "Name": "Panel", "ControlName": "xt"},
 	)
 
-	y_offset = 19
+	y_offset = 0
 	for index, message in enumerate(messages, start=1):
 		rows = collect_signal_rows(message)
 		group_height = max(180, 82 + len(rows) * 50)

--- a/xodr_converter/xvp_generator.py
+++ b/xodr_converter/xvp_generator.py
@@ -27,7 +27,7 @@ PHYSICAL_VALUE_CONTROL_X = 533
 PHYSICAL_MIN_MAX_X = 787
 SPECIAL_VALUE_X = 945
 INACTIVE_VALUE_X = 1050
-MIN_MAX_FONT = "Microsoft Sans Serif, 7pt"
+MIN_MAX_FONT = "Microsoft Sans Serif, 9.25pt"
 
 
 @dataclass

--- a/xodr_converter/xvp_generator.py
+++ b/xodr_converter/xvp_generator.py
@@ -27,6 +27,7 @@ PHYSICAL_VALUE_CONTROL_X = 533
 PHYSICAL_MIN_MAX_X = 787
 SPECIAL_VALUE_X = 945
 INACTIVE_VALUE_X = 1050
+MIN_MAX_FONT = "Microsoft Sans Serif, 7pt"
 
 
 @dataclass
@@ -308,7 +309,7 @@ def add_physical_min_max_text(
 		y,
 		120,
 		16,
-		font="Microsoft Sans Serif, 8.25pt",
+		font=MIN_MAX_FONT,
 		fore_color="255, 0, 0, 0",
 	)
 	add_static_text(
@@ -318,7 +319,7 @@ def add_physical_min_max_text(
 		y + 18,
 		150,
 		16,
-		font="Microsoft Sans Serif, 8.25pt",
+		font=MIN_MAX_FONT,
 		fore_color="255, 0, 0, 0",
 	)
 

--- a/xodr_converter/xvp_generator.py
+++ b/xodr_converter/xvp_generator.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import re
 import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -43,7 +44,7 @@ class SignalRow:
 	use_inactive_member: Optional[StructMemberInfo] = None
 
 
-def generation_xvp(sysvar_path: str, selected_variables: Dict[str, List[str]], output_dir: str) -> str:
+def generation_xvp(sysvar_path: str, selected_variables: Dict[str, List[str]], output_dir: str) -> List[str]:
 	"""
 	生成 CANoe 面板文件(.xvp)。
 
@@ -53,16 +54,30 @@ def generation_xvp(sysvar_path: str, selected_variables: Dict[str, List[str]], o
 		output_dir: 输出目录完整路径。
 
 	Returns:
-		生成的 .xvp 文件路径。
+		生成的 .xvp 文件路径列表。每个选中的 message 会生成一个独立文件。
 	"""
 	messages = parse_selected_messages(sysvar_path, selected_variables)
-	panel_tree = build_panel_tree(messages)
-
 	os.makedirs(output_dir, exist_ok=True)
-	output_name = f"{Path(sysvar_path).stem}_panel.xvp"
-	output_path = str(Path(output_dir) / output_name)
-	panel_tree.write(output_path, encoding="utf-8", xml_declaration=True)
-	return output_path
+
+	output_paths: List[str] = []
+	for message in messages:
+		panel_tree = build_panel_tree([message])
+		output_name = panel_file_name(sysvar_path, message)
+		output_path = str(Path(output_dir) / output_name)
+		panel_tree.write(output_path, encoding="utf-8", xml_declaration=True)
+		output_paths.append(output_path)
+
+	return output_paths
+
+
+def panel_file_name(sysvar_path: str, message: MessageInfo) -> str:
+	base_name = Path(sysvar_path).stem
+	return f"{safe_filename(base_name)}_{safe_filename(message.namespace)}_{safe_filename(message.variable_name)}_panel.xvp"
+
+
+def safe_filename(value: str) -> str:
+	name = re.sub(r"[^0-9A-Za-z_]+", "_", value).strip("_")
+	return name or "panel"
 
 
 def parse_selected_messages(sysvar_path: str, selected_variables: Dict[str, List[str]]) -> List[MessageInfo]:

--- a/xodr_converter/xvp_generator.py
+++ b/xodr_converter/xvp_generator.py
@@ -41,6 +41,7 @@ class StructMemberInfo:
 	name: str
 	member_type: str
 	comment: str = ""
+	start_value: str = ""
 	min_value: str = "~"
 	max_value: str = "~"
 	valuetable: Dict[str, str] = field(default_factory=dict)
@@ -52,6 +53,7 @@ class MessageInfo:
 	variable_name: str
 	struct_name: str
 	members: Dict[str, StructMemberInfo]
+	node_name: str = ""
 
 
 @dataclass
@@ -90,8 +92,8 @@ def generation_xvp(sysvar_path: str, selected_variables: Dict[str, List[str]], o
 
 
 def panel_file_name(sysvar_path: str, message: MessageInfo) -> str:
-	base_name = Path(sysvar_path).stem
-	return f"{safe_filename(base_name)}_{safe_filename(message.namespace)}_{safe_filename(message.variable_name)}_panel.xvp"
+	node_name = message.node_name or "node"
+	return f"{safe_filename(message.namespace)}_{safe_filename(node_name)}_{safe_filename(message.variable_name)}_panel.xvp"
 
 
 def safe_filename(value: str) -> str:
@@ -132,6 +134,7 @@ def parse_selected_messages(sysvar_path: str, selected_variables: Dict[str, List
 					variable_name=variable_name,
 					struct_name=struct_name,
 					members=parse_struct_members(struct),
+					node_name=message_node_name(variable_name, struct),
 				)
 			)
 
@@ -162,11 +165,20 @@ def parse_struct_members(struct: ET.Element) -> Dict[str, StructMemberInfo]:
 			name=member_name,
 			member_type=member.get("type", ""),
 			comment=member.get("comment", ""),
+			start_value=member.get("startValue", ""),
 			min_value=member.get("minValue", "~"),
 			max_value=member.get("maxValue", "~"),
 			valuetable=parse_value_table(member),
 		)
 	return members
+
+
+def message_node_name(variable_name: str, struct: ET.Element) -> str:
+	node_member_name = f"{variable_name}_node"
+	for member in struct.findall("./structMember"):
+		if member.get("name", "") == node_member_name:
+			return member.get("startValue", "")
+	return ""
 
 
 def parse_value_table(member: ET.Element) -> Dict[str, str]:

--- a/xodr_converter/xvp_generator.py
+++ b/xodr_converter/xvp_generator.py
@@ -18,6 +18,16 @@ COMBO_BOX_TYPE = "Vector.CANalyzer.Panels.Design.ComboBoxControl, Vector.CANalyz
 RADIO_BUTTON_TYPE = "Vector.CANalyzer.Panels.Design.RadioButtonControl, Vector.CANalyzer.Panels.CommonControls, Version=18.0.150.0, Culture=neutral, PublicKeyToken=null"
 CANVAS_TYPE = "Vector.CANalyzer.Panels.Design.CanvasControl, Vector.CANalyzer.Panels.CommonControls, Version=18.0.150.0, Culture=neutral, PublicKeyToken=null"
 
+GROUP_WIDTH = 1160
+PANEL_WIDTH = 1170
+SIGNAL_RAW_SEPARATOR_X = 211
+RAW_PHYSICAL_SEPARATOR_X = 485
+PHYSICAL_SPECIAL_SEPARATOR_X = 930
+PHYSICAL_VALUE_CONTROL_X = 533
+PHYSICAL_MIN_MAX_X = 787
+SPECIAL_VALUE_X = 945
+INACTIVE_VALUE_X = 1050
+
 
 @dataclass
 class StructMemberInfo:
@@ -175,7 +185,6 @@ def build_panel_tree(messages: Sequence[MessageInfo]) -> ET.ElementTree:
 	)
 
 	y_offset = 19
-	panel_width = 1012
 	for index, message in enumerate(messages, start=1):
 		rows = collect_signal_rows(message)
 		group_height = max(180, 82 + len(rows) * 50)
@@ -183,7 +192,7 @@ def build_panel_tree(messages: Sequence[MessageInfo]) -> ET.ElementTree:
 		y_offset += group_height + 20
 
 	add_property(root_object, "Name", "Panel")
-	add_property(root_object, "Size", f"{panel_width}, {max(725, y_offset)}")
+	add_property(root_object, "Size", f"{PANEL_WIDTH}, {max(725, y_offset)}")
 	add_property(root_object, "Location", "0, 0")
 	add_property(root_object, "BackColor", "255, 255, 255, 255")
 
@@ -237,7 +246,7 @@ def add_message_group(
 		add_horizontal_line(group, y + 35, row_index + 10)
 
 	add_property(group, "Name", group.get("Name", ""))
-	add_property(group, "Size", f"1007, {group_height}")
+	add_property(group, "Size", f"{GROUP_WIDTH}, {group_height}")
 	add_property(group, "Location", f"5, {y_offset}")
 	add_property(group, "BackColor", "WhiteSmoke")
 	add_property(group, "Font", "Microsoft Sans Serif, 12.25pt")
@@ -249,20 +258,20 @@ def add_message_group(
 def add_headers_and_separators(group: ET.Element, group_height: int) -> None:
 	add_static_text(group, "Signal Name", 50, 47, 94, 19, fore_color="255, 225, 128, 48")
 	add_static_text(group, "Raw Value", 304, 47, 81, 19, fore_color="255, 225, 128, 48")
-	add_static_text(group, "Physical Value", 583, 47, 107, 19, fore_color="255, 225, 128, 48")
-	add_static_text(group, "Special Value", 833, 47, 120, 19, fore_color="255, 225, 128, 48")
+	add_static_text(group, "Physical Value", 660, 47, 120, 19, fore_color="255, 225, 128, 48")
+	add_static_text(group, "Special Value", 995, 47, 120, 19, fore_color="255, 225, 128, 48")
 
-	add_vertical_line(group, 211, 47, group_height - 38, 1)
-	add_vertical_line(group, 485, 47, group_height - 38, 2)
-	add_vertical_line(group, 758, 47, group_height - 38, 3)
+	add_vertical_line(group, SIGNAL_RAW_SEPARATOR_X, 47, group_height - 38, 1)
+	add_vertical_line(group, RAW_PHYSICAL_SEPARATOR_X, 47, group_height - 38, 2)
+	add_vertical_line(group, PHYSICAL_SPECIAL_SEPARATOR_X, 47, group_height - 38, 3)
 	add_horizontal_line(group, 79, 4)
 
 
 def add_signal_row(group: ET.Element, message: MessageInfo, row: SignalRow, y: int, row_index: int) -> None:
 	add_static_text(group, row.name, 0, y, 190, 19)
 	add_value_control(group, message, row.raw_member, 256, y - 2, "RawValue", row_index * 10 + 1)
-	add_value_control(group, message, row.physical_member, 533, y - 2, "PhysicalValue", row_index * 10 + 2)
-	add_physical_min_max_text(group, row.physical_member, 533, y + 24)
+	add_value_control(group, message, row.physical_member, PHYSICAL_VALUE_CONTROL_X, y - 2, "PhysicalValue", row_index * 10 + 2)
+	add_physical_min_max_text(group, row.physical_member, PHYSICAL_MIN_MAX_X, y - 4)
 
 	if row.use_special_member is not None:
 		add_radio_button(
@@ -270,7 +279,7 @@ def add_signal_row(group: ET.Element, message: MessageInfo, row: SignalRow, y: i
 			message,
 			row.use_special_member,
 			"special value",
-			772,
+			SPECIAL_VALUE_X,
 			y,
 			row_index * 10 + 3,
 		)
@@ -280,7 +289,7 @@ def add_signal_row(group: ET.Element, message: MessageInfo, row: SignalRow, y: i
 			message,
 			row.use_inactive_member,
 			"inactive value",
-			878,
+			INACTIVE_VALUE_X,
 			y,
 			row_index * 10 + 4,
 		)
@@ -294,13 +303,23 @@ def add_physical_min_max_text(
 ) -> None:
 	add_static_text(
 		parent,
-		f"min: {member.min_value}    max: {member.max_value}",
+		f"min: {member.min_value}",
 		x,
 		y,
-		210,
+		120,
 		16,
 		font="Microsoft Sans Serif, 8.25pt",
-		fore_color="255, 96, 96, 96",
+		fore_color="255, 0, 0, 0",
+	)
+	add_static_text(
+		parent,
+		f"max: {member.max_value}",
+		x,
+		y + 18,
+		150,
+		16,
+		font="Microsoft Sans Serif, 8.25pt",
+		fore_color="255, 0, 0, 0",
 	)
 
 
@@ -424,7 +443,7 @@ def add_vertical_line(parent: ET.Element, x: int, y: int, height: int, tab_index
 
 
 def add_horizontal_line(parent: ET.Element, y: int, tab_index: int) -> None:
-	add_canvas(parent, -5, y, 1007, 3, tab_index)
+	add_canvas(parent, -5, y, GROUP_WIDTH, 3, tab_index)
 
 
 def add_canvas(parent: ET.Element, x: int, y: int, width: int, height: int, tab_index: int) -> None:

--- a/xodr_converter/xvp_generator.py
+++ b/xodr_converter/xvp_generator.py
@@ -24,6 +24,8 @@ class StructMemberInfo:
 	name: str
 	member_type: str
 	comment: str = ""
+	min_value: str = "~"
+	max_value: str = "~"
 	valuetable: Dict[str, str] = field(default_factory=dict)
 
 
@@ -143,6 +145,8 @@ def parse_struct_members(struct: ET.Element) -> Dict[str, StructMemberInfo]:
 			name=member_name,
 			member_type=member.get("type", ""),
 			comment=member.get("comment", ""),
+			min_value=member.get("minValue", "~"),
+			max_value=member.get("maxValue", "~"),
 			valuetable=parse_value_table(member),
 		)
 	return members
@@ -258,6 +262,7 @@ def add_signal_row(group: ET.Element, message: MessageInfo, row: SignalRow, y: i
 	add_static_text(group, row.name, 0, y, 190, 19)
 	add_value_control(group, message, row.raw_member, 256, y - 2, "RawValue", row_index * 10 + 1)
 	add_value_control(group, message, row.physical_member, 533, y - 2, "PhysicalValue", row_index * 10 + 2)
+	add_physical_min_max_text(group, row.physical_member, 533, y + 24)
 
 	if row.use_special_member is not None:
 		add_radio_button(
@@ -279,6 +284,24 @@ def add_signal_row(group: ET.Element, message: MessageInfo, row: SignalRow, y: i
 			y,
 			row_index * 10 + 4,
 		)
+
+
+def add_physical_min_max_text(
+	parent: ET.Element,
+	member: StructMemberInfo,
+	x: int,
+	y: int,
+) -> None:
+	add_static_text(
+		parent,
+		f"min: {member.min_value}    max: {member.max_value}",
+		x,
+		y,
+		210,
+		16,
+		font="Microsoft Sans Serif, 8.25pt",
+		fore_color="255, 96, 96, 96",
+	)
 
 
 def add_value_control(
@@ -380,6 +403,7 @@ def add_static_text(
 	width: int,
 	height: int,
 	fore_color: Optional[str] = None,
+	font: str = "Microsoft Sans Serif, 11.25pt",
 ) -> None:
 	control = ET.SubElement(
 		parent,
@@ -391,7 +415,7 @@ def add_static_text(
 	add_property(control, "Location", f"{x}, {y}")
 	if fore_color:
 		add_property(control, "ForeColor", fore_color)
-	add_property(control, "Font", "Microsoft Sans Serif, 11.25pt")
+	add_property(control, "Font", font)
 	add_property(control, "Text", text)
 
 

--- a/xodr_converter/xvp_generator.py
+++ b/xodr_converter/xvp_generator.py
@@ -23,6 +23,10 @@ PANEL_WIDTH = 1170
 SIGNAL_RAW_SEPARATOR_X = 211
 RAW_PHYSICAL_SEPARATOR_X = 485
 PHYSICAL_SPECIAL_SEPARATOR_X = 930
+RAW_VALUE_CONTROL_X = 256
+RAW_MIN_MAX_X = 385
+RAW_TEXT_BOX_WIDTH = 120
+DEFAULT_VALUE_CONTROL_WIDTH = 187
 PHYSICAL_VALUE_CONTROL_X = 533
 PHYSICAL_MIN_MAX_X = 787
 SPECIAL_VALUE_X = 945
@@ -272,9 +276,22 @@ def add_headers_and_separators(group: ET.Element, group_height: int) -> None:
 
 def add_signal_row(group: ET.Element, message: MessageInfo, row: SignalRow, y: int, row_index: int) -> None:
 	add_static_text(group, row.name, 0, y, 190, 19)
-	add_value_control(group, message, row.raw_member, 256, y - 2, "RawValue", row_index * 10 + 1)
+	if row.raw_member.valuetable:
+		add_value_control(group, message, row.raw_member, RAW_VALUE_CONTROL_X, y - 2, "RawValue", row_index * 10 + 1)
+	else:
+		add_value_control(
+			group,
+			message,
+			row.raw_member,
+			RAW_VALUE_CONTROL_X,
+			y - 2,
+			"RawValue",
+			row_index * 10 + 1,
+			width=RAW_TEXT_BOX_WIDTH,
+		)
+		add_min_max_text(group, row.raw_member, RAW_MIN_MAX_X, y - 4)
 	add_value_control(group, message, row.physical_member, PHYSICAL_VALUE_CONTROL_X, y - 2, "PhysicalValue", row_index * 10 + 2)
-	add_physical_min_max_text(group, row.physical_member, PHYSICAL_MIN_MAX_X, y - 4)
+	add_min_max_text(group, row.physical_member, PHYSICAL_MIN_MAX_X, y - 4)
 
 	if row.use_special_member is not None:
 		add_radio_button(
@@ -298,7 +315,7 @@ def add_signal_row(group: ET.Element, message: MessageInfo, row: SignalRow, y: i
 		)
 
 
-def add_physical_min_max_text(
+def add_min_max_text(
 	parent: ET.Element,
 	member: StructMemberInfo,
 	x: int,
@@ -334,21 +351,30 @@ def add_value_control(
 	y: int,
 	used_value_table: str,
 	tab_index: int,
+	width: int = DEFAULT_VALUE_CONTROL_WIDTH,
 ) -> None:
 	if member.valuetable:
-		add_combo_box(parent, message, member, x, y, tab_index)
+		add_combo_box(parent, message, member, x, y, tab_index, width=width)
 	else:
-		add_text_box(parent, message, member, x, y, used_value_table, tab_index)
+		add_text_box(parent, message, member, x, y, used_value_table, tab_index, width=width)
 
 
-def add_combo_box(parent: ET.Element, message: MessageInfo, member: StructMemberInfo, x: int, y: int, tab_index: int) -> None:
+def add_combo_box(
+	parent: ET.Element,
+	message: MessageInfo,
+	member: StructMemberInfo,
+	x: int,
+	y: int,
+	tab_index: int,
+	width: int = DEFAULT_VALUE_CONTROL_WIDTH,
+) -> None:
 	control = ET.SubElement(
 		parent,
 		"Object",
 		{"Type": COMBO_BOX_TYPE, "Name": object_name(), "ControlName": f"Combo Box {tab_index}"},
 	)
 	add_property(control, "Name", control.get("Name", ""))
-	add_property(control, "Size", "187, 23")
+	add_property(control, "Size", f"{width}, 23")
 	add_property(control, "Location", f"{x}, {y}")
 	add_property(control, "DisplayLabel", "Left")
 	add_property(control, "DescriptionSize", "5, 23")
@@ -366,6 +392,7 @@ def add_text_box(
 	y: int,
 	used_value_table: str,
 	tab_index: int,
+	width: int = DEFAULT_VALUE_CONTROL_WIDTH,
 ) -> None:
 	control = ET.SubElement(
 		parent,
@@ -373,7 +400,7 @@ def add_text_box(
 		{"Type": TEXT_BOX_TYPE, "Name": object_name(), "ControlName": f"Input/Output Box {tab_index}"},
 	)
 	add_property(control, "Name", control.get("Name", ""))
-	add_property(control, "Size", "187, 25")
+	add_property(control, "Size", f"{width}, 25")
 	add_property(control, "Location", f"{x}, {y}")
 	add_property(control, "AlarmGeneralSettings", alarm_general_settings(member))
 	add_property(control, "AlarmLowerBkgColor", "Salmon")

--- a/xodr_converter/xvp_generator.py
+++ b/xodr_converter/xvp_generator.py
@@ -1,0 +1,414 @@
+from __future__ import annotations
+
+import os
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence
+from xml.etree import ElementTree as ET
+
+
+PANEL_TYPE = "Vector.CANalyzer.Panels.PanelSerializer, Vector.CANalyzer.Panels.Serializer, Version=18.0.150.0, Culture=neutral, PublicKeyToken=null"
+RUNTIME_PANEL_TYPE = "Vector.CANalyzer.Panels.Runtime.Panel, Vector.CANalyzer.Panels.Common, Version=18.0.150.0, Culture=neutral, PublicKeyToken=null"
+GROUP_BOX_TYPE = "Vector.CANalyzer.Panels.Design.GroupBoxControl, Vector.CANalyzer.Panels.CommonControls, Version=18.0.150.0, Culture=neutral, PublicKeyToken=null"
+STATIC_TEXT_TYPE = "Vector.CANalyzer.Panels.Design.StaticTextControl, Vector.CANalyzer.Panels.CommonControls, Version=18.0.150.0, Culture=neutral, PublicKeyToken=null"
+TEXT_BOX_TYPE = "Vector.CANalyzer.Panels.Design.TextBoxControl, Vector.CANalyzer.Panels.CommonControls, Version=18.0.150.0, Culture=neutral, PublicKeyToken=null"
+COMBO_BOX_TYPE = "Vector.CANalyzer.Panels.Design.ComboBoxControl, Vector.CANalyzer.Panels.CommonControls, Version=18.0.150.0, Culture=neutral, PublicKeyToken=null"
+RADIO_BUTTON_TYPE = "Vector.CANalyzer.Panels.Design.RadioButtonControl, Vector.CANalyzer.Panels.CommonControls, Version=18.0.150.0, Culture=neutral, PublicKeyToken=null"
+CANVAS_TYPE = "Vector.CANalyzer.Panels.Design.CanvasControl, Vector.CANalyzer.Panels.CommonControls, Version=18.0.150.0, Culture=neutral, PublicKeyToken=null"
+
+
+@dataclass
+class StructMemberInfo:
+	name: str
+	member_type: str
+	comment: str = ""
+	valuetable: Dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class MessageInfo:
+	namespace: str
+	variable_name: str
+	struct_name: str
+	members: Dict[str, StructMemberInfo]
+
+
+@dataclass
+class SignalRow:
+	name: str
+	raw_member: StructMemberInfo
+	physical_member: StructMemberInfo
+	use_special_member: Optional[StructMemberInfo] = None
+	use_inactive_member: Optional[StructMemberInfo] = None
+
+
+def generation_xvp(sysvar_path: str, selected_variables: Dict[str, List[str]], output_dir: str) -> str:
+	"""
+	生成 CANoe 面板文件(.xvp)。
+
+	Args:
+		sysvar_path: 系统变量文件完整路径。
+		selected_variables: {"namespace": ["MessageName", ...]}。
+		output_dir: 输出目录完整路径。
+
+	Returns:
+		生成的 .xvp 文件路径。
+	"""
+	messages = parse_selected_messages(sysvar_path, selected_variables)
+	panel_tree = build_panel_tree(messages)
+
+	os.makedirs(output_dir, exist_ok=True)
+	output_name = f"{Path(sysvar_path).stem}_panel.xvp"
+	output_path = str(Path(output_dir) / output_name)
+	panel_tree.write(output_path, encoding="utf-8", xml_declaration=True)
+	return output_path
+
+
+def parse_selected_messages(sysvar_path: str, selected_variables: Dict[str, List[str]]) -> List[MessageInfo]:
+	tree = ET.parse(sysvar_path)
+	root = tree.getroot()
+	namespace_map: Dict[str, ET.Element] = {}
+
+	for namespace in root.findall(".//namespace"):
+		namespace_path = namespace.get("name", "")
+		if namespace_path:
+			namespace_map[namespace_path] = namespace
+
+	messages: List[MessageInfo] = []
+	for namespace_name, variable_names in selected_variables.items():
+		namespace = namespace_map.get(namespace_name)
+		if namespace is None:
+			continue
+
+		struct_map = {struct.get("name", ""): struct for struct in namespace.findall("./struct")}
+		for variable_name in variable_names:
+			variable = find_variable(namespace, variable_name)
+			if variable is None:
+				continue
+
+			struct_name = struct_name_from_definition(variable.get("structDefinition", ""))
+			struct = struct_map.get(struct_name)
+			if struct is None:
+				continue
+
+			messages.append(
+				MessageInfo(
+					namespace=namespace_name,
+					variable_name=variable_name,
+					struct_name=struct_name,
+					members=parse_struct_members(struct),
+				)
+			)
+
+	return messages
+
+
+def find_variable(namespace: ET.Element, variable_name: str) -> Optional[ET.Element]:
+	for variable in namespace.findall("./variable"):
+		if variable.get("name") == variable_name:
+			return variable
+	return None
+
+
+def struct_name_from_definition(struct_definition: str) -> str:
+	if "::" not in struct_definition:
+		return struct_definition
+	return struct_definition.rsplit("::", 1)[1]
+
+
+def parse_struct_members(struct: ET.Element) -> Dict[str, StructMemberInfo]:
+	members: Dict[str, StructMemberInfo] = {}
+	for member in struct.findall("./structMember"):
+		member_name = member.get("name", "")
+		if not member_name:
+			continue
+
+		members[member_name] = StructMemberInfo(
+			name=member_name,
+			member_type=member.get("type", ""),
+			comment=member.get("comment", ""),
+			valuetable=parse_value_table(member),
+		)
+	return members
+
+
+def parse_value_table(member: ET.Element) -> Dict[str, str]:
+	value_table = member.find("./valuetable")
+	if value_table is None:
+		return {}
+
+	entries: Dict[str, str] = {}
+	for entry in value_table.findall("./valuetableentry"):
+		value = entry.get("value", "")
+		display = entry.get("displayString", "") or entry.get("description", "")
+		if value:
+			entries[value] = display
+	return entries
+
+
+def build_panel_tree(messages: Sequence[MessageInfo]) -> ET.ElementTree:
+	panel = ET.Element("Panel", {"Type": PANEL_TYPE})
+	root_object = ET.SubElement(
+		panel,
+		"Object",
+		{"Type": RUNTIME_PANEL_TYPE, "Name": "Panel", "ControlName": "xt"},
+	)
+
+	y_offset = 19
+	panel_width = 1012
+	for index, message in enumerate(messages, start=1):
+		rows = collect_signal_rows(message)
+		group_height = max(180, 82 + len(rows) * 50)
+		add_message_group(root_object, message, rows, y_offset, group_height, index)
+		y_offset += group_height + 20
+
+	add_property(root_object, "Name", "Panel")
+	add_property(root_object, "Size", f"{panel_width}, {max(725, y_offset)}")
+	add_property(root_object, "Location", "0, 0")
+	add_property(root_object, "BackColor", "255, 255, 255, 255")
+
+	tree = ET.ElementTree(panel)
+	ET.indent(tree, space="  ")
+	return tree
+
+
+def collect_signal_rows(message: MessageInfo) -> List[SignalRow]:
+	rows: List[SignalRow] = []
+	for member_name, member in message.members.items():
+		if not member_name.endswith("_Rv"):
+			continue
+
+		signal_name = member_name[: -len("_Rv")]
+		physical_member = message.members.get(f"{signal_name}_Pv")
+		if physical_member is None:
+			continue
+
+		rows.append(
+			SignalRow(
+				name=signal_name,
+				raw_member=member,
+				physical_member=physical_member,
+				use_special_member=message.members.get(f"{signal_name}_use_special_value"),
+				use_inactive_member=message.members.get(f"{signal_name}_use_inactive_value"),
+			)
+		)
+	return rows
+
+
+def add_message_group(
+	parent: ET.Element,
+	message: MessageInfo,
+	rows: Sequence[SignalRow],
+	y_offset: int,
+	group_height: int,
+	group_index: int,
+) -> None:
+	group = ET.SubElement(
+		parent,
+		"Object",
+		{"Type": GROUP_BOX_TYPE, "Name": object_name(), "ControlName": f"Group Box {group_index}"},
+	)
+
+	add_headers_and_separators(group, group_height)
+
+	for row_index, row in enumerate(rows):
+		y = 94 + row_index * 50
+		add_signal_row(group, message, row, y, row_index + 1)
+		add_horizontal_line(group, y + 35, row_index + 10)
+
+	add_property(group, "Name", group.get("Name", ""))
+	add_property(group, "Size", f"1007, {group_height}")
+	add_property(group, "Location", f"5, {y_offset}")
+	add_property(group, "BackColor", "WhiteSmoke")
+	add_property(group, "Font", "Microsoft Sans Serif, 12.25pt")
+	add_property(group, "Text", f"Message Name: {message.variable_name}")
+	add_property(group, "TabIndex", str(group_index))
+	add_property(group, "UseWindowsStyle", "False")
+
+
+def add_headers_and_separators(group: ET.Element, group_height: int) -> None:
+	add_static_text(group, "Signal Name", 50, 47, 94, 19, fore_color="255, 225, 128, 48")
+	add_static_text(group, "Raw Value", 304, 47, 81, 19, fore_color="255, 225, 128, 48")
+	add_static_text(group, "Physical Value", 583, 47, 107, 19, fore_color="255, 225, 128, 48")
+	add_static_text(group, "Special Value", 833, 47, 120, 19, fore_color="255, 225, 128, 48")
+
+	add_vertical_line(group, 211, 47, group_height - 38, 1)
+	add_vertical_line(group, 485, 47, group_height - 38, 2)
+	add_vertical_line(group, 758, 47, group_height - 38, 3)
+	add_horizontal_line(group, 79, 4)
+
+
+def add_signal_row(group: ET.Element, message: MessageInfo, row: SignalRow, y: int, row_index: int) -> None:
+	add_static_text(group, row.name, 0, y, 190, 19)
+	add_value_control(group, message, row.raw_member, 256, y - 2, "RawValue", row_index * 10 + 1)
+	add_value_control(group, message, row.physical_member, 533, y - 2, "PhysicalValue", row_index * 10 + 2)
+
+	if row.use_special_member is not None:
+		add_radio_button(
+			group,
+			message,
+			row.use_special_member,
+			"special value",
+			772,
+			y,
+			row_index * 10 + 3,
+		)
+	if row.use_inactive_member is not None:
+		add_radio_button(
+			group,
+			message,
+			row.use_inactive_member,
+			"inactive value",
+			878,
+			y,
+			row_index * 10 + 4,
+		)
+
+
+def add_value_control(
+	parent: ET.Element,
+	message: MessageInfo,
+	member: StructMemberInfo,
+	x: int,
+	y: int,
+	used_value_table: str,
+	tab_index: int,
+) -> None:
+	if member.valuetable:
+		add_combo_box(parent, message, member, x, y, tab_index)
+	else:
+		add_text_box(parent, message, member, x, y, used_value_table, tab_index)
+
+
+def add_combo_box(parent: ET.Element, message: MessageInfo, member: StructMemberInfo, x: int, y: int, tab_index: int) -> None:
+	control = ET.SubElement(
+		parent,
+		"Object",
+		{"Type": COMBO_BOX_TYPE, "Name": object_name(), "ControlName": f"Combo Box {tab_index}"},
+	)
+	add_property(control, "Name", control.get("Name", ""))
+	add_property(control, "Size", "187, 23")
+	add_property(control, "Location", f"{x}, {y}")
+	add_property(control, "DisplayLabel", "Left")
+	add_property(control, "DescriptionSize", "5, 23")
+	add_property(control, "Font", "Microsoft Sans Serif, 11.25pt")
+	add_property(control, "TabIndex", str(tab_index))
+	add_property(control, "DescriptionText", "")
+	add_property(control, "SymbolConfiguration", symbol_configuration(message, member.name))
+
+
+def add_text_box(
+	parent: ET.Element,
+	message: MessageInfo,
+	member: StructMemberInfo,
+	x: int,
+	y: int,
+	used_value_table: str,
+	tab_index: int,
+) -> None:
+	control = ET.SubElement(
+		parent,
+		"Object",
+		{"Type": TEXT_BOX_TYPE, "Name": object_name(), "ControlName": f"Input/Output Box {tab_index}"},
+	)
+	add_property(control, "Name", control.get("Name", ""))
+	add_property(control, "Size", "187, 25")
+	add_property(control, "Location", f"{x}, {y}")
+	add_property(control, "AlarmGeneralSettings", "1;3;0;3")
+	add_property(control, "AlarmLowerBkgColor", "Salmon")
+	add_property(control, "AlarmLowerTextColor", "ControlText")
+	add_property(control, "AlarmUpperBkgColor", "IndianRed")
+	add_property(control, "AlarmUpperTextColor", "ControlText")
+	add_property(control, "BoxBorderStyle", "FixedSingle")
+	add_property(control, "DisplayLabel", "Left")
+	add_property(control, "BoxFont", "Verdana, 11.25pt")
+	add_property(control, "AlarmLowerFont", "Verdana, 11.25pt")
+	add_property(control, "AlarmUpperFont", "Verdana, 11.25pt")
+	add_property(control, "TextFont", "Verdana, 7pt, style=Bold")
+	add_property(control, "TabIndex", str(tab_index))
+	add_property(control, "DescriptionText", "")
+	add_property(control, "ValueDecimalPlaces", "0" if member.member_type == "int" else "3")
+	add_property(control, "ValueDisplay", "Double")
+	add_property(control, "UsedValueTable", used_value_table)
+	add_property(control, "DescriptionSize", "5, 25")
+	add_property(control, "SymbolConfiguration", symbol_configuration(message, member.name))
+
+
+def add_radio_button(
+	parent: ET.Element,
+	message: MessageInfo,
+	member: StructMemberInfo,
+	text: str,
+	x: int,
+	y: int,
+	tab_index: int,
+) -> None:
+	control = ET.SubElement(
+		parent,
+		"Object",
+		{"Type": RADIO_BUTTON_TYPE, "Name": object_name(), "ControlName": f"Radio Button {tab_index}"},
+	)
+	add_property(control, "Name", control.get("Name", ""))
+	add_property(control, "Size", "96, 17")
+	add_property(control, "Location", f"{x}, {y}")
+	add_property(control, "Text", text)
+	add_property(control, "TabIndex", str(tab_index))
+	add_property(control, "SymbolConfiguration", symbol_configuration(message, member.name))
+
+
+def add_static_text(
+	parent: ET.Element,
+	text: str,
+	x: int,
+	y: int,
+	width: int,
+	height: int,
+	fore_color: Optional[str] = None,
+) -> None:
+	control = ET.SubElement(
+		parent,
+		"Object",
+		{"Type": STATIC_TEXT_TYPE, "Name": object_name(), "ControlName": "Static Text"},
+	)
+	add_property(control, "Name", control.get("Name", ""))
+	add_property(control, "Size", f"{width}, {height}")
+	add_property(control, "Location", f"{x}, {y}")
+	if fore_color:
+		add_property(control, "ForeColor", fore_color)
+	add_property(control, "Font", "Microsoft Sans Serif, 11.25pt")
+	add_property(control, "Text", text)
+
+
+def add_vertical_line(parent: ET.Element, x: int, y: int, height: int, tab_index: int) -> None:
+	add_canvas(parent, x, y, 2, height, tab_index)
+
+
+def add_horizontal_line(parent: ET.Element, y: int, tab_index: int) -> None:
+	add_canvas(parent, -5, y, 1007, 3, tab_index)
+
+
+def add_canvas(parent: ET.Element, x: int, y: int, width: int, height: int, tab_index: int) -> None:
+	control = ET.SubElement(
+		parent,
+		"Object",
+		{"Type": CANVAS_TYPE, "Name": object_name(), "ControlName": f"Canvas {tab_index}"},
+	)
+	add_property(control, "Name", control.get("Name", ""))
+	add_property(control, "Size", f"{width}, {height}")
+	add_property(control, "Location", f"{x}, {y}")
+	add_property(control, "BackColor", "255, 31, 73, 125")
+	add_property(control, "TabIndex", str(tab_index))
+
+
+def symbol_configuration(message: MessageInfo, member_name: str) -> str:
+	return f"8;128;{message.namespace};;{message.variable_name};{member_name};2;;;-1;;;Value;;;0"
+
+
+def add_property(parent: ET.Element, name: str, value: str) -> None:
+	prop = ET.SubElement(parent, "Property", {"Name": name})
+	prop.text = value
+
+
+def object_name() -> str:
+	return f"X{uuid.uuid4().hex}"

--- a/xodr_converter/xvp_generator.py
+++ b/xodr_converter/xvp_generator.py
@@ -442,7 +442,7 @@ def add_static_text(
 	control = ET.SubElement(
 		parent,
 		"Object",
-		{"Type": STATIC_TEXT_TYPE, "Name": object_name(), "ControlName": "Static Text"},
+		{"Type": STATIC_TEXT_TYPE, "Name": object_name(), "ControlName": f"Static Text {short_id()}"},
 	)
 	add_property(control, "Name", control.get("Name", ""))
 	add_property(control, "Size", f"{width}, {height}")
@@ -485,3 +485,7 @@ def add_property(parent: ET.Element, name: str, value: str) -> None:
 
 def object_name() -> str:
 	return f"X{uuid.uuid4().hex}"
+
+
+def short_id() -> str:
+	return uuid.uuid4().hex[:8]

--- a/xodr_converter/xvp_generator.py
+++ b/xodr_converter/xvp_generator.py
@@ -248,7 +248,7 @@ def add_message_group(
 
 	add_property(group, "Name", group.get("Name", ""))
 	add_property(group, "Size", f"{GROUP_WIDTH}, {group_height}")
-	add_property(group, "Location", f"5, {y_offset}")
+	add_property(group, "Location", f"0, {y_offset}")
 	add_property(group, "BackColor", "WhiteSmoke")
 	add_property(group, "Font", "Microsoft Sans Serif, 12.25pt")
 	add_property(group, "Text", f"Message Name: {message.variable_name}")

--- a/xodr_converter/xvp_generator.py
+++ b/xodr_converter/xvp_generator.py
@@ -420,7 +420,7 @@ def add_radio_button(
 def alarm_general_settings(member: StructMemberInfo) -> str:
 	lower_limit = member.min_value if member.min_value != "~" else DEFAULT_LOWER_LIMIT
 	upper_limit = member.max_value if member.max_value != "~" else DEFAULT_UPPER_LIMIT
-	return f"1;{upper_limit};{lower_limit};3"
+	return f"1;3;{lower_limit};{upper_limit}"
 
 
 def value_display(member: StructMemberInfo) -> str:

--- a/xodr_converter/xvp_generator.py
+++ b/xodr_converter/xvp_generator.py
@@ -373,7 +373,7 @@ def add_text_box(
 	add_property(control, "Name", control.get("Name", ""))
 	add_property(control, "Size", "187, 25")
 	add_property(control, "Location", f"{x}, {y}")
-	add_property(control, "AlarmGeneralSettings", "1;3;0;3")
+	add_property(control, "AlarmGeneralSettings", alarm_general_settings(member))
 	add_property(control, "AlarmLowerBkgColor", "Salmon")
 	add_property(control, "AlarmLowerTextColor", "ControlText")
 	add_property(control, "AlarmUpperBkgColor", "IndianRed")
@@ -413,6 +413,12 @@ def add_radio_button(
 	add_property(control, "Text", text)
 	add_property(control, "TabIndex", str(tab_index))
 	add_property(control, "SymbolConfiguration", symbol_configuration(message, member.name))
+
+
+def alarm_general_settings(member: StructMemberInfo) -> str:
+	lower_limit = member.min_value if member.min_value != "~" else "0"
+	upper_limit = member.max_value if member.max_value != "~" else "0"
+	return f"1;{upper_limit};{lower_limit};3"
 
 
 def add_static_text(

--- a/xodr_converter/xvp_generator.py
+++ b/xodr_converter/xvp_generator.py
@@ -389,7 +389,7 @@ def add_text_box(
 	add_property(control, "TabIndex", str(tab_index))
 	add_property(control, "DescriptionText", "")
 	add_property(control, "ValueDecimalPlaces", "0" if member.member_type == "int" else "3")
-	add_property(control, "ValueDisplay", "Double")
+	add_property(control, "ValueDisplay", value_display(member))
 	add_property(control, "UsedValueTable", used_value_table)
 	add_property(control, "DescriptionSize", "5, 25")
 	add_property(control, "SymbolConfiguration", symbol_configuration(message, member.name))
@@ -421,6 +421,12 @@ def alarm_general_settings(member: StructMemberInfo) -> str:
 	lower_limit = member.min_value if member.min_value != "~" else DEFAULT_LOWER_LIMIT
 	upper_limit = member.max_value if member.max_value != "~" else DEFAULT_UPPER_LIMIT
 	return f"1;{upper_limit};{lower_limit};3"
+
+
+def value_display(member: StructMemberInfo) -> str:
+	if member.member_type == "int":
+		return "Decimal"
+	return "Double"
 
 
 def add_static_text(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add a Python converter that reads one or more DBC files via `cantools` and writes a single CANoe `.vsysvar` XML file.
- Generate one namespace per DBC, node info structs and variables from `BU_` nodes, one struct and variable per message, and Pv/Rv/Factor/Offset members per signal.
- Add sender node string members to each message struct using the DBC `BO_` sender node.
- Add per-message `_info` structs with MsgOn, MsgOff, MsgSendType, periodic MsgCycleTime, and CE fast-send controls from DBC attributes.
- Split DBC `VAL_` entries into normal enum choices and out-of-range special values; normal enum choices stay on `_Rv`, `_Pv` gets a physical-valued table only when its type is `int`, every signal gets `has_special_value`, and only signals with special values get `use_special_value` and `special_value` members with value tables.
- Add inactive value support from `GenSigInactiveValue`: every signal gets `has_inactive_value`, and only signals with inactive values get `use_inactive_value` and `inactive_value` members.
- Add `generation_xvp()` to build one CANoe `.xvp` panel per selected `.vsysvar` message variable, including physical and raw min/max labels read from `.vsysvar` (`~` when absent), aligned inside their value areas; generated filenames include namespace, sender node, and message name.
- Configure generated `TextBoxControl` alarm limits from `.vsysvar` min/max using `AlarmGeneralSettings` field 3 as Lower Limit and field 4 as Upper Limit; when missing, use `-2147483648/2147483647` defaults, and use `ValueDisplay=Decimal` for `int` members.
- Generate unique `ControlName` values for static text controls to improve CANoe import compatibility.
- Force all `type="int"` struct members to `bitcount="32"`; non-int members retain their specified bitcount, and variable `bitcount` is summed from actual generated struct member bitcounts.
- Use explicit DBC encoding only: default `utf-8-sig`, or user-provided `--dbc-encoding` such as `gb18030`, `gbk`, or `cp936`; invalid bytes are replaced instead of aborting conversion.

## Testing
- `python3 -m unittest test_dbc_to_vsysvar.py`
- `python3 -m unittest test_xvp_generator.py`
- `python3 -m py_compile xodr_converter/dbc_to_vsysvar.py test_dbc_to_vsysvar.py`
- `python3 -m py_compile xodr_converter/xvp_generator.py test_xvp_generator.py`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aa5d7c53-bd9f-4f5d-88b0-b63c2d8347b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aa5d7c53-bd9f-4f5d-88b0-b63c2d8347b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

