### PR TITLE
feat(capl): 按发送节点从系统变量生成报文模拟 CAPL

### DIFF
--- a/case_editor/src/capl_generator.py
+++ b/case_editor/src/capl_generator.py
@@ -484,11 +484,17 @@ def _build_linkage_handlers(namespace: str, message_name: str, model: MessageMod
         sv_pv = f"{namespace}::{message_name}.{signal.name}_Pv"
         sv_rv = f"{namespace}::{message_name}.{signal.name}_Rv"
 
-        # Pv 改变 -> 重算 Rv（Rv = round((Pv - Offset)/Factor)）
+        # Pv 改变 -> 重算 Rv（Rv = round((Pv - Offset)/Factor)），并夹到 Rv 的 min/max。
         lines.append(f"on sysvar {sv_pv}")
         lines.append("{")
         lines.append("  long _newRv;")
         lines.append(f"  _newRv = round(({pv} - ({offset_lit})) / ({factor_lit}));")
+        if signal.rv_min is not None and signal.rv_min != "":
+            lines.append(f"  if (_newRv < {signal.rv_min})")
+            lines.append(f"    _newRv = {signal.rv_min};")
+        if signal.rv_max is not None and signal.rv_max != "":
+            lines.append(f"  if (_newRv > {signal.rv_max})")
+            lines.append(f"    _newRv = {signal.rv_max};")
         lines.append(f"  if (_newRv != {rv})")
         lines.append(f"    {rv} = _newRv;")
         lines.append("}")

--- a/case_editor/src/capl_generator.py
+++ b/case_editor/src/capl_generator.py
@@ -717,3 +717,40 @@ def generate_capl(config: Dict[str, Any], project_path) -> List[str]:
             generated.append(str(file_path))
 
     return generated
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="根据系统变量(.vsysvar)为各发送节点生成 CANoe CAPL(.can) 文件"
+    )
+    parser.add_argument(
+        "--project",
+        required=True,
+        help=r"项目根目录，例如 D:\Test\case_editor\projects\proj1",
+    )
+    parser.add_argument(
+        "--config",
+        help="config 的 JSON 文件路径（内容为传给 generate_capl 的 config 字典）",
+    )
+    parser.add_argument(
+        "--sysvar",
+        help="可选：直接指定 .vsysvar 路径，覆盖 config 里的 selected_system_variable_file",
+    )
+    args = parser.parse_args()
+
+    # 读取 config：优先用 --config 指定的 JSON 文件，否则构造一个仅含系统变量文件的空配置。
+    if args.config:
+        with open(args.config, "r", encoding="utf-8") as fh:
+            run_config: Dict[str, Any] = json.load(fh)
+    else:
+        run_config = {"dbc_configs": [], "selected_system_variable_file": args.sysvar or ""}
+
+    if args.sysvar:
+        run_config["selected_system_variable_file"] = args.sysvar
+
+    generated_files = generate_capl(run_config, args.project)
+    print(f"共生成 {len(generated_files)} 个 .can 文件：")
+    for generated_file in generated_files:
+        print("  ", generated_file)

--- a/case_editor/src/capl_generator.py
+++ b/case_editor/src/capl_generator.py
@@ -5,16 +5,13 @@ CAPL 生成器
 为每个发送节点生成一个独立的 CANoe CAPL 节点文件（.can）。
 
 设计要点：
-- 信号清单与元数据（Factor/Offset、Rv 的 min/max、是否有 special/inactive）全部从
+- 信号清单与元数据（Factor/Offset、Rv 的 min/max、special、SigSendType 等）全部从
   .vsysvar 文件解析得到，运行时不依赖原始 DBC。
 - CAN 通道号从项目的 project.json -> canoe.dbc_files 读取（channel 为 0 基，实际通道 = channel + 1）。
-- 每个报文按系统变量进行模拟发送：
-    * 节点/报文开关：<ns>_Node_On、<ns>_Node_Info.<sender>_MsgOn、<msg>_Info.<msg>_MsgOn/_MsgOff
-    * 发送类型：当前仅实现 Cycle（MsgSendType == 0），周期取 <msg>_Info.<msg>_MsgCycleTime
-    * 信号取值优先级：special > inactive > 普通值；报文对象 msg.信号 赋物理值（CAPL 自动编码成 raw），
-      普通值用 Pv，special/inactive/counter/checksum 等 raw 码按 Factor/Offset 转成物理值再赋
-    * counter 在 [min,max] 间递增到顶再回到 min
-    * checksum 使用查表版 CRC16-CCITT 或 sum 校验
+- 每个报文按系统变量进行模拟发送，支持 MsgSendType：
+    Cycle / Event / IfActive / CE / CA（数值与 DBC GenMsgSendType 一致：0~4）。
+- 信号取值优先级：special > 普通值（不再使用 inactive 赋值）；报文对象 msg.信号 赋物理值。
+- counter/checksum 可受 {msg}_WrongCounterFlag / {msg}_WrongCRCFlag 影响（为 1 时在计算结果上 +1）。
 - Pv/Rv 通过各自的 _Factor/_Offset 系统变量双向联动，并做防抖避免 on sysvar 互相触发死循环。
 """
 from __future__ import annotations
@@ -30,6 +27,13 @@ from xml.etree import ElementTree as ET
 # 数据模型
 # ----------------------------------------------------------------------------
 
+# MsgSendType 数值（与 DBC GenMsgSendType / .vsysvar valuetable 一致）
+MSG_SEND_CYCLE = 0
+MSG_SEND_EVENT = 1
+MSG_SEND_IF_ACTIVE = 2
+MSG_SEND_CE = 3
+MSG_SEND_CA = 4
+
 # 单个信号在 .vsysvar 报文结构里的成员后缀（带前导下划线）。
 # 注意：匹配时必须按“长后缀优先”，否则 _special_value 会错误命中 _has_special_value。
 _SIGNAL_SUFFIXES = [
@@ -39,11 +43,15 @@ _SIGNAL_SUFFIXES = [
     "_use_inactive_value",
     "_special_value",
     "_inactive_value",
+    "_SigSendType",
     "_Factor",
     "_Offset",
     "_Pv",
     "_Rv",
 ]
+
+# 参与 Event/CE 触发监听的信号成员后缀（不含 Factor/Offset/has_*/SigSendType 等元数据）
+_WATCHABLE_SUFFIXES = ("_Pv", "_Rv", "_use_special_value")
 
 
 @dataclass
@@ -55,10 +63,25 @@ class SignalModel:
     rv_min: Optional[str] = None
     rv_max: Optional[str] = None
     pv_is_int: bool = True
-    has_special_value: bool = False   # 是否存在 _special_value 成员
-    has_inactive_value: bool = False  # 是否存在 _inactive_value 成员
+    has_special_value: bool = False
+    has_inactive_value: bool = False  # 用于 IfActive/CA 判定，不参与赋值
+    inactive_raw: Optional[str] = None
     has_pv: bool = False
     has_rv: bool = False
+    has_sig_send_type: bool = False
+    sig_send_type_choices: Dict[int, str] = field(default_factory=dict)
+
+
+@dataclass
+class MessageInfoModel:
+    """报文 *_Info 结构中的发送控制字段。"""
+    message_name: str
+    has_msg_send_type: bool = False
+    has_msg_cycle_time: bool = False
+    has_msg_cycle_time_fast: bool = False
+    has_msg_nr_of_repetition: bool = False
+    has_wrong_crc_flag: bool = False
+    has_wrong_counter_flag: bool = False
 
 
 @dataclass
@@ -67,6 +90,7 @@ class MessageModel:
     name: str
     signals: List[SignalModel] = field(default_factory=list)
     signal_index: Dict[str, SignalModel] = field(default_factory=dict)
+    info: Optional[MessageInfoModel] = None
 
     def get(self, signal_name: str) -> Optional[SignalModel]:
         return self.signal_index.get(signal_name)
@@ -76,8 +100,9 @@ class MessageModel:
 class ParsedSysvar:
     """.vsysvar 解析结果。"""
     messages: Dict[str, MessageModel] = field(default_factory=dict)
-    variable_names: set = field(default_factory=set)   # 所有 variable 的名称
-    member_names: set = field(default_factory=set)      # 所有 structMember 的名称
+    message_infos: Dict[str, MessageInfoModel] = field(default_factory=dict)
+    variable_names: set = field(default_factory=set)
+    member_names: set = field(default_factory=set)
 
 
 # ----------------------------------------------------------------------------
@@ -90,6 +115,66 @@ def _split_signal_member(member_name: str) -> Optional[Tuple[str, str]]:
         if member_name.endswith(suffix):
             return member_name[: -len(suffix)], suffix
     return None
+
+
+def _parse_value_table(member: ET.Element) -> Dict[int, str]:
+    """从 structMember 子节点 valuetable 解析 {数值: 描述}。"""
+    table: Dict[int, str] = {}
+    vt = member.find("valuetable")
+    if vt is None:
+        return table
+    for entry in vt.findall("valuetableentry"):
+        value_text = entry.get("value", "")
+        desc = entry.get("description", "") or entry.get("name", "") or ""
+        try:
+            if value_text.strip().lower().startswith("0x"):
+                key = int(value_text.strip(), 16)
+            else:
+                key = int(float(value_text))
+        except (TypeError, ValueError):
+            continue
+        table[key] = desc.strip()
+    return table
+
+
+def _choice_value_by_name(choices: Dict[int, str], *names: str) -> Optional[int]:
+    """按名称（不区分大小写、忽略空格）在 valuetable 中查找数值。"""
+    targets = {n.lower().replace(" ", "").replace("_", "") for n in names}
+    for value, desc in choices.items():
+        normalized = desc.lower().replace(" ", "").replace("_", "")
+        if normalized in targets:
+            return value
+    return None
+
+
+def _resolve_sig_send_types(choices: Dict[int, str]) -> Tuple[int, int, int]:
+    """解析 SigSendType valuetable，返回 (cycle, on_change, on_write) 的数值。"""
+    cycle = _choice_value_by_name(choices, "Cycle", "Cyclic", "cycle", "cyclic")
+    on_change = _choice_value_by_name(choices, "OnChange", "onchange")
+    on_write = _choice_value_by_name(choices, "OnWrite", "onwrite")
+    return cycle if cycle is not None else 0, on_change if on_change is not None else 1, on_write if on_write is not None else 2
+
+
+def _build_message_info_model(message_name: str, members: List[ET.Element]) -> MessageInfoModel:
+    model = MessageInfoModel(message_name=message_name)
+    prefix = f"{message_name}_"
+    for member in members:
+        name = member.get("name", "")
+        if not name.startswith(prefix):
+            continue
+        if name == f"{message_name}_MsgSendType":
+            model.has_msg_send_type = True
+        elif name == f"{message_name}_MsgCycleTime":
+            model.has_msg_cycle_time = True
+        elif name == f"{message_name}_MsgCycleTimeFast":
+            model.has_msg_cycle_time_fast = True
+        elif name == f"{message_name}_MsgNrOfRepetition":
+            model.has_msg_nr_of_repetition = True
+        elif name == f"{message_name}_WrongCRCFlag":
+            model.has_wrong_crc_flag = True
+        elif name == f"{message_name}_WrongCounterFlag":
+            model.has_wrong_counter_flag = True
+    return model
 
 
 def parse_vsysvar(vsysvar_path: str) -> ParsedSysvar:
@@ -121,7 +206,25 @@ def parse_vsysvar(vsysvar_path: str) -> ParsedSysvar:
         if name:
             result.variable_names.add(name)
 
-    # 2) 找到所有“报文数据变量”：type=struct 且 structDefinition 指向的 struct 名
+    # 解析 *_Info 结构（报文发送控制字段）
+    for variable in root.iter("variable"):
+        if variable.get("type") != "struct":
+            continue
+        var_name = variable.get("name", "")
+        if not var_name.endswith("_Info"):
+            continue
+        struct_def = variable.get("structDefinition", "")
+        if not struct_def:
+            continue
+        struct_simple = struct_def.split("::")[-1].lower()
+        members = structs.get(struct_simple)
+        if members is None:
+            continue
+        msg_name = var_name[: -len("_Info")]
+        info_model = _build_message_info_model(msg_name, members)
+        result.message_infos[msg_name] = info_model
+
+    # 2) 找到所有“报文数据变量”
     #    等于变量名的小写（报文数据结构命名规则为 message.name.lower()）。
     for variable in root.iter("variable"):
         if variable.get("type") != "struct":
@@ -139,6 +242,7 @@ def parse_vsysvar(vsysvar_path: str) -> ParsedSysvar:
             continue
         model = _build_message_model(var_name, members)
         if model.signals:
+            model.info = result.message_infos.get(var_name)
             result.messages[var_name] = model
     return result
 
@@ -181,6 +285,10 @@ def _apply_member(signal: SignalModel, suffix: str, member: ET.Element) -> None:
         signal.has_special_value = True
     elif suffix == "_inactive_value":
         signal.has_inactive_value = True
+        signal.inactive_raw = member.get("startValue")
+    elif suffix == "_SigSendType":
+        signal.has_sig_send_type = True
+        signal.sig_send_type_choices = _parse_value_table(member)
 
 
 def _read_text_any_encoding(path: str) -> str:
@@ -258,6 +366,16 @@ def _counter_enabled(msg_cfg: Dict[str, Any], model: MessageModel) -> bool:
 
 def _info_var(message_name: str) -> str:
     return f"{message_name}_Info"
+
+
+def _info_member_exists(parsed: ParsedSysvar, message_name: str, suffix: str) -> bool:
+    return f"{message_name}{suffix}" in parsed.member_names
+
+
+def _info_sysvar(namespace: str, message_name: str, member: str, parsed: ParsedSysvar, default: str) -> str:
+    if _info_member_exists(parsed, message_name, member):
+        return _sysvar(namespace, _info_var(message_name), f"{message_name}{member}")
+    return default
 
 
 def _to_capl_number(text: Optional[str], default: str) -> str:
@@ -385,6 +503,7 @@ def _build_fill_function(
     namespace: str,
     message_name: str,
     model: MessageModel,
+    parsed: ParsedSysvar,
     has_validation: bool,
     counter_signal: str,
     check_signal: str,
@@ -416,19 +535,24 @@ def _build_fill_function(
         lines.append("  dword _crc;")
         lines.append("")
 
-    # 1) 普通信号：special > inactive > Rv
+    # 1) 普通信号：special > 普通值（不再使用 inactive 赋值）
     for signal in model.signals:
         if signal.name in (counter_signal, check_signal):
             continue
         lines.extend(_build_signal_assignment(namespace, message_name, signal))
 
-    # 2) counter：写当前值（raw 计数转物理值），再在 [min,max] 间递增/回绕
+    # 2) counter：写当前值，再递增；WrongCounterFlag==1 时在结果上 +1
     if has_counter:
         counter = model.get(counter_signal)
         cmin = _to_capl_number(counter.rv_min, "0")
         cmax = _to_capl_number(counter.rv_max, "255")
         cnt_phys = _phys_expr(cnt_var, _format_float(counter.factor, "1"), _format_float(counter.offset, "0"))
-        lines.append(f"  {msg}.{counter_signal} = {cnt_phys};")
+        wrong_counter = _info_sysvar(namespace, message_name, "_WrongCounterFlag", parsed, "0")
+        if model.info and model.info.has_wrong_counter_flag:
+            cnt_assign = f"({cnt_phys}) + (({wrong_counter} == 1) ? 1 : 0)"
+        else:
+            cnt_assign = cnt_phys
+        lines.append(f"  {msg}.{counter_signal} = {cnt_assign};")
         lines.append(f"  if ({cnt_var} >= {cmax})")
         lines.append(f"    {cnt_var} = {cmin};")
         lines.append("  else")
@@ -457,8 +581,12 @@ def _build_fill_function(
             lines.append(
                 f"  _crc = PROJ_CRC16_CCITT(_data, _n, {init}, {poly}, {xor_out});"
             )
-        else:  # sum 校验
+        else:
             lines.append("  _crc = PROJ_Checksum(_data, _n);")
+        wrong_crc = _info_sysvar(namespace, message_name, "_WrongCRCFlag", parsed, "0")
+        if model.info and model.info.has_wrong_crc_flag:
+            lines.append(f"  if ({wrong_crc} == 1)")
+            lines.append("    _crc = _crc + 1;")
         lines.append(f"  {msg}.{check_signal} = {crc_phys};")
 
     lines.append("}")
@@ -482,21 +610,13 @@ def _build_signal_assignment(namespace: str, message_name: str, signal: SignalMo
 
     lines: List[str] = []
     branches: List[Tuple[str, str]] = []
-    # special 优先级高于 inactive：需同时满足“定义了该值(has_*==1)”且“启用(use_*==1)”。
-    # special/inactive 在系统变量里是 raw 码，需转成物理值再赋给报文信号。
+    # special：需同时满足 has_special_value==1 且 use_special_value==1。
     if signal.has_special_value:
         has_special = _sysvar(namespace, message_name, f"{signal.name}_has_special_value")
         use_special = _sysvar(namespace, message_name, f"{signal.name}_use_special_value")
         special_value = _sysvar(namespace, message_name, f"{signal.name}_special_value")
         branches.append(
             (f"{has_special} == 1 && {use_special} == 1", _phys_expr(special_value, factor_lit, offset_lit))
-        )
-    if signal.has_inactive_value:
-        has_inactive = _sysvar(namespace, message_name, f"{signal.name}_has_inactive_value")
-        use_inactive = _sysvar(namespace, message_name, f"{signal.name}_use_inactive_value")
-        inactive_value = _sysvar(namespace, message_name, f"{signal.name}_inactive_value")
-        branches.append(
-            (f"{has_inactive} == 1 && {use_inactive} == 1", _phys_expr(inactive_value, factor_lit, offset_lit))
         )
 
     if not branches:
@@ -509,6 +629,235 @@ def _build_signal_assignment(namespace: str, message_name: str, signal: SignalMo
         lines.append(f"    {target} = {value};")
     lines.append("  else")
     lines.append(f"    {target} = {normal_value};")
+    return lines
+
+
+def _shadow_var(message_name: str, member_name: str) -> str:
+    return f"g_prev_{message_name}_{member_name}"
+
+
+def _restore_var(message_name: str, member_name: str) -> str:
+    return f"g_restore_{message_name}_{member_name}"
+
+
+def _capl_member_type(signal: SignalModel, suffix: str) -> str:
+    if suffix == "_Pv":
+        return "int" if signal.pv_is_int else "float"
+    if suffix == "_Rv":
+        return "long"
+    return "long"
+
+
+def _watchable_members(
+    model: MessageModel,
+    exclude: Optional[set] = None,
+) -> List[Tuple[SignalModel, str]]:
+    """返回需要监听变化的 (信号, 后缀) 列表。"""
+    exclude = exclude or set()
+    items: List[Tuple[SignalModel, str]] = []
+    for signal in model.signals:
+        if signal.name in exclude:
+            continue
+        for suffix in _WATCHABLE_SUFFIXES:
+            member = f"{signal.name}{suffix}"
+            if suffix == "_Pv" and signal.has_pv:
+                items.append((signal, suffix))
+            elif suffix == "_Rv" and signal.has_rv:
+                items.append((signal, suffix))
+            elif suffix == "_use_special_value" and signal.has_special_value:
+                items.append((signal, suffix))
+    return items
+
+
+def _inactive_phys_expr(namespace: str, message_name: str, signal: SignalModel) -> str:
+    inactive_raw = _sysvar(namespace, message_name, f"{signal.name}_inactive_value")
+    return _phys_expr(inactive_raw, _format_float(signal.factor, "1"), _format_float(signal.offset, "0"))
+
+
+def _inactive_raw_expr(namespace: str, message_name: str, signal: SignalModel) -> str:
+    return _sysvar(namespace, message_name, f"{signal.name}_inactive_value")
+
+
+def _restore_pending_var(message_name: str, member_name: str) -> str:
+    return f"restore_pending_{message_name}_{member_name}"
+
+
+def _build_burst_variables(message_name: str, model: MessageModel, exclude: Optional[set] = None) -> List[str]:
+    lines = [
+        f"  long burst_left_{message_name};",
+        f"  long burst_fast_{message_name};",
+    ]
+    for signal, suffix in _watchable_members(model, exclude):
+        member = f"{signal.name}{suffix}"
+        capl_type = _capl_member_type(signal, suffix)
+        lines.append(f"  {capl_type} {_shadow_var(message_name, member)};")
+        lines.append(f"  {capl_type} {_restore_var(message_name, member)};")
+        lines.append(f"  long {_restore_pending_var(message_name, member)};")
+    return lines
+
+
+def _build_init_shadows(namespace: str, message_name: str, model: MessageModel, exclude: Optional[set] = None) -> List[str]:
+    lines: List[str] = []
+    for signal, suffix in _watchable_members(model, exclude):
+        member = f"{signal.name}{suffix}"
+        sv = _sysvar(namespace, message_name, member)
+        lines.append(f"  {_shadow_var(message_name, member)} = {sv};")
+    return lines
+
+
+def _build_begin_burst_function(namespace: str, message_name: str, parsed: ParsedSysvar) -> List[str]:
+    info = _info_var(message_name)
+    rep = _info_sysvar(namespace, message_name, "_MsgNrOfRepetition", parsed, "1")
+    return [
+        f"void begin_burst_{message_name}(long use_fast)",
+        "{",
+        f"  burst_left_{message_name} = {rep};",
+        "  if (burst_left_{0} <= 0)".format(message_name),
+        f"    burst_left_{message_name} = 1;",
+        f"  burst_fast_{message_name} = use_fast;",
+        f"  cancelTimer(tmr_{message_name});",
+        f"  send_{message_name}();",
+        f"  burst_left_{message_name}--;",
+        f"  if (burst_left_{message_name} > 0)",
+        f"    arm_{message_name}();",
+        "  else",
+        f"    finish_burst_{message_name}();",
+        "}",
+        "",
+    ]
+
+
+def _build_finish_burst_function(
+    namespace: str,
+    message_name: str,
+    model: MessageModel,
+    parsed: ParsedSysvar,
+    exclude: Optional[set] = None,
+) -> List[str]:
+    send_type_expr = _info_sysvar(namespace, message_name, "_MsgSendType", parsed, str(MSG_SEND_CYCLE))
+    lines = [f"void finish_burst_{message_name}()", "{"]
+    for signal, suffix in _watchable_members(model, exclude):
+        member = f"{signal.name}{suffix}"
+        pending = _restore_pending_var(message_name, member)
+        sv = _sysvar(namespace, message_name, member)
+        lines.append(f"  if ({pending})")
+        lines.append("  {")
+        lines.append(f"    {sv} = {_restore_var(message_name, member)};")
+        lines.append(f"    {_shadow_var(message_name, member)} = {_restore_var(message_name, member)};")
+        lines.append(f"    {pending} = 0;")
+        lines.append("  }")
+    lines.append(f"  burst_fast_{message_name} = 0;")
+    lines.append(f"  if ({send_type_expr} == {MSG_SEND_EVENT} || {send_type_expr} == {MSG_SEND_IF_ACTIVE})")
+    lines.append("    return;")
+    lines.append(f"  arm_{message_name}();")
+    lines.append("}")
+    lines.append("")
+    return lines
+
+
+def _build_trigger_handlers(
+    namespace: str,
+    message_name: str,
+    model: MessageModel,
+    parsed: ParsedSysvar,
+    exclude: Optional[set] = None,
+) -> List[str]:
+    """为 Event / CE / IfActive / CA 生成 on sysvar 触发处理器。"""
+    exclude = exclude or set()
+    info = model.info
+    if info is None or not info.has_msg_send_type:
+        return []
+
+    send_type_expr = _info_sysvar(namespace, message_name, "_MsgSendType", parsed, str(MSG_SEND_CYCLE))
+    lines: List[str] = []
+
+    for signal, suffix in _watchable_members(model, exclude):
+        member = f"{signal.name}{suffix}"
+        sv_path = f"{namespace}::{message_name}.{member}"
+        sv = _sysvar(namespace, message_name, member)
+        shadow = _shadow_var(message_name, member)
+        capl_type = _capl_member_type(signal, suffix)
+
+        sig_send_type_expr = None
+        cycle_type, on_change_type, on_write_type = 0, 1, 2
+        if signal.has_sig_send_type:
+            sig_send_type_expr = _sysvar(namespace, message_name, f"{signal.name}_SigSendType")
+            cycle_type, on_change_type, on_write_type = _resolve_sig_send_types(signal.sig_send_type_choices)
+
+        inactive_cmp = None
+        if signal.has_inactive_value and suffix in ("_Pv", "_Rv"):
+            if suffix == "_Pv":
+                inactive_cmp = f"_new != ({_inactive_phys_expr(namespace, message_name, signal)})"
+            else:
+                inactive_cmp = f"_new != ({_inactive_raw_expr(namespace, message_name, signal)})"
+
+        lines.append(f"on sysvar {sv_path}")
+        lines.append("{")
+        lines.append(f"  {capl_type} _old, _new;")
+        lines.append("  long _triggered, _use_fast;")
+        lines.append(f"  _old = {shadow};")
+        lines.append(f"  _new = {sv};")
+        lines.append("  _triggered = 0;")
+        lines.append("  _use_fast = 0;")
+
+        # Event
+        lines.append(f"  if ({send_type_expr} == {MSG_SEND_EVENT} && _old != _new)")
+        lines.append("  {")
+        lines.append("    _triggered = 1;")
+        lines.append("    _use_fast = 0;")
+        lines.append("  }")
+
+        # IfActive
+        if inactive_cmp:
+            lines.append(
+                f"  else if ({send_type_expr} == {MSG_SEND_IF_ACTIVE} && _old != _new && ({inactive_cmp}))"
+            )
+            lines.append("  {")
+            lines.append("    _triggered = 1;")
+            lines.append("    _use_fast = 0;")
+            lines.append("  }")
+
+        # CE
+        if sig_send_type_expr:
+            lines.append(
+                f"  else if ({send_type_expr} == {MSG_SEND_CE} && {sig_send_type_expr} == {on_change_type}"
+                f" && _old != _new)"
+            )
+            lines.append("  {")
+            lines.append("    _triggered = 1;")
+            lines.append("    _use_fast = 1;")
+            lines.append("  }")
+            lines.append(
+                f"  else if ({send_type_expr} == {MSG_SEND_CE} && {sig_send_type_expr} == {on_write_type})"
+            )
+            lines.append("  {")
+            lines.append("    _triggered = 1;")
+            lines.append("    _use_fast = 1;")
+            lines.append("  }")
+
+        # CA
+        if inactive_cmp and sig_send_type_expr:
+            lines.append(
+                f"  else if ({send_type_expr} == {MSG_SEND_CA} && {sig_send_type_expr} != {cycle_type}"
+                f" && _old != _new && ({inactive_cmp}))"
+            )
+            lines.append("  {")
+            lines.append("    _triggered = 1;")
+            lines.append("    _use_fast = 1;")
+            lines.append("  }")
+
+        lines.append("  if (_triggered)")
+        lines.append("  {")
+        lines.append(f"    {_restore_pending_var(message_name, member)} = 1;")
+        lines.append(f"    {_restore_var(message_name, member)} = _old;")
+        lines.append(f"    {shadow} = _new;")
+        lines.append(f"    begin_burst_{message_name}(_use_fast);")
+        lines.append("  }")
+        lines.append("  else")
+        lines.append(f"    {shadow} = _new;")
+        lines.append("}")
+        lines.append("")
+
     return lines
 
 
@@ -612,10 +961,18 @@ def _build_can_file(
         out.append(f"  msTimer tmr_{name};")
         if _counter_enabled(msg_cfg, model):
             out.append(f"  long cnt_{name};")
+        exclude = set()
+        if msg_cfg.get("has_validation", False):
+            for key in ("check_signal", "counter_signal"):
+                sig = msg_cfg.get(key, "")
+                if sig:
+                    exclude.add(sig)
+        if model.info and model.info.has_msg_send_type:
+            out.extend(_build_burst_variables(name, model, exclude))
     out.append("}")
     out.append("")
 
-    # on start：设置通道、初始化 counter、装载定时器
+    # on start：设置通道、初始化 counter、影子变量、装载定时器
     out.append("on start")
     out.append("{")
     for msg_cfg, model in messages:
@@ -625,21 +982,50 @@ def _build_can_file(
             counter = model.get(msg_cfg.get("counter_signal", ""))
             cmin = _to_capl_number(counter.rv_min, "0")
             out.append(f"  cnt_{name} = {cmin};")
-        out.append(f"  arm_{name}();")
+        exclude = set()
+        if msg_cfg.get("has_validation", False):
+            for key in ("check_signal", "counter_signal"):
+                sig = msg_cfg.get(key, "")
+                if sig:
+                    exclude.add(sig)
+        if model.info and model.info.has_msg_send_type:
+            out.append(f"  burst_left_{name} = 0;")
+            out.append(f"  burst_fast_{name} = 0;")
+            for signal, suffix in _watchable_members(model, exclude):
+                member = f"{signal.name}{suffix}"
+                out.append(f"  {_restore_pending_var(name, member)} = 0;")
+            out.extend(_build_init_shadows(namespace, name, model, exclude))
+        send_type = MSG_SEND_CYCLE
+        if model.info and model.info.has_msg_send_type:
+            out.append(f"  if ({_info_sysvar(namespace, name, '_MsgSendType', parsed, str(MSG_SEND_CYCLE))} != {MSG_SEND_EVENT}"
+                       f" && {_info_sysvar(namespace, name, '_MsgSendType', parsed, str(MSG_SEND_CYCLE))} != {MSG_SEND_IF_ACTIVE})")
+            out.append(f"    arm_{name}();")
+        else:
+            out.append(f"  arm_{name}();")
     out.append("}")
     out.append("")
 
-    # 每条报文：装载函数 + 定时器事件 + 发送函数 + 填充函数
+    # 每条报文：burst / 装载 / 定时器 / 发送 / 填充
     for msg_cfg, model in messages:
         name = model.name
+        exclude = set()
+        if msg_cfg.get("has_validation", False):
+            for key in ("check_signal", "counter_signal"):
+                sig = msg_cfg.get(key, "")
+                if sig:
+                    exclude.add(sig)
+        if model.info and model.info.has_msg_send_type:
+            out.extend(_build_begin_burst_function(namespace, name, parsed))
+            out.extend(_build_finish_burst_function(namespace, name, model, parsed, exclude))
         out.extend(_build_arm_function(namespace, name, parsed))
-        out.extend(_build_timer_handler(name))
+        out.extend(_build_timer_handler(namespace, name, parsed))
         out.extend(_build_send_function(namespace, dbc_name, sender_node, name, parsed))
         out.extend(
             _build_fill_function(
                 namespace,
                 name,
                 model,
+                parsed,
                 bool(msg_cfg.get("has_validation", False)),
                 msg_cfg.get("counter_signal", ""),
                 msg_cfg.get("check_signal", ""),
@@ -647,6 +1033,8 @@ def _build_can_file(
                 msg_cfg.get("check_parameters", {}),
             )
         )
+        if model.info and model.info.has_msg_send_type:
+            out.extend(_build_trigger_handlers(namespace, name, model, parsed, exclude))
 
     # Pv/Rv 联动（跳过 checksum/counter 这类程序自动计算、不接受外部输入的信号）
     for msg_cfg, model in messages:
@@ -661,17 +1049,21 @@ def _build_can_file(
     return "\n".join(out) + "\n"
 
 
-def _build_arm_function(namespace: str, message_name: str, parsed: "ParsedSysvar") -> List[str]:
-    info = _info_var(message_name)
-    if info in parsed.variable_names:
-        cycle_expr = _sysvar(namespace, info, f"{message_name}_MsgCycleTime")
-    else:
-        cycle_expr = "10"  # 无 *_Info 时使用默认周期
+def _build_arm_function(namespace: str, message_name: str, parsed: ParsedSysvar) -> List[str]:
+    cycle_expr = _info_sysvar(namespace, message_name, "_MsgCycleTime", parsed, "10")
+    fast_expr = _info_sysvar(namespace, message_name, "_MsgCycleTimeFast", parsed, cycle_expr)
+    send_type_expr = _info_sysvar(namespace, message_name, "_MsgSendType", parsed, str(MSG_SEND_CYCLE))
     return [
         f"void arm_{message_name}()",
         "{",
         "  long _ct;",
-        f"  _ct = {cycle_expr};",
+        f"  if (({send_type_expr} == {MSG_SEND_EVENT} || {send_type_expr} == {MSG_SEND_IF_ACTIVE})"
+        f" && burst_left_{message_name} <= 0)",
+        "    return;",
+        f"  if (burst_left_{message_name} > 0 && burst_fast_{message_name})",
+        f"    _ct = {fast_expr};",
+        "  else",
+        f"    _ct = {cycle_expr};",
         "  if (_ct <= 0)",
         "    _ct = 10;",
         f"  setTimer(tmr_{message_name}, _ct);",
@@ -680,12 +1072,21 @@ def _build_arm_function(namespace: str, message_name: str, parsed: "ParsedSysvar
     ]
 
 
-def _build_timer_handler(message_name: str) -> List[str]:
+def _build_timer_handler(namespace: str, message_name: str, parsed: ParsedSysvar) -> List[str]:
     return [
         f"on timer tmr_{message_name}",
         "{",
         f"  send_{message_name}();",
-        f"  arm_{message_name}();",
+        f"  if (burst_left_{message_name} > 0)",
+        "  {",
+        f"    burst_left_{message_name}--;",
+        f"    if (burst_left_{message_name} <= 0)",
+        f"      finish_burst_{message_name}();",
+        "    else",
+        f"      arm_{message_name}();",
+        "  }",
+        "  else",
+        f"    arm_{message_name}();",
         "}",
         "",
     ]
@@ -712,8 +1113,11 @@ def _build_send_function(
     if info in parsed.variable_names:
         lines.append(f"  if ({_sysvar(namespace, info, message_name + '_MsgOn')} != 1) return;")
         lines.append(f"  if ({_sysvar(namespace, info, message_name + '_MsgOff')} == 1) return;")
-        # 仅 Cycle 类型（MsgSendType == 0）
-        lines.append(f"  if ({_sysvar(namespace, info, message_name + '_MsgSendType')} != 0) return;")
+        send_type_expr = _info_sysvar(namespace, message_name, "_MsgSendType", parsed, str(MSG_SEND_CYCLE))
+        lines.append(
+            f"  if (({send_type_expr} == {MSG_SEND_EVENT} || {send_type_expr} == {MSG_SEND_IF_ACTIVE})"
+            f" && burst_left_{message_name} <= 0) return;"
+        )
     lines.append(f"  fill_{message_name}();")
     lines.append(f"  output({_msg_var(message_name)});")
     lines.append("}")

--- a/case_editor/src/capl_generator.py
+++ b/case_editor/src/capl_generator.py
@@ -125,7 +125,7 @@ def _parse_value_table(member: ET.Element) -> Dict[int, str]:
         return table
     for entry in vt.findall("valuetableentry"):
         value_text = entry.get("value", "")
-        desc = entry.get("description", "") or entry.get("name", "") or ""
+        desc = entry.get("description", "") or entry.get("displayString", "") or entry.get("name", "") or ""
         try:
             if value_text.strip().lower().startswith("0x"):
                 key = int(value_text.strip(), 16)
@@ -148,11 +148,18 @@ def _choice_value_by_name(choices: Dict[int, str], *names: str) -> Optional[int]
 
 
 def _resolve_sig_send_types(choices: Dict[int, str]) -> Tuple[int, int, int]:
-    """解析 SigSendType valuetable，返回 (cycle, on_change, on_write) 的数值。"""
+    """解析 SigSendType valuetable，返回 (cycle, on_change, on_write) 的数值。
+
+    若 valuetable 缺失，默认与常见 DBC 定义一致：Cycle=0, OnWrite=1, OnChange=2。
+    """
     cycle = _choice_value_by_name(choices, "Cycle", "Cyclic", "cycle", "cyclic")
     on_change = _choice_value_by_name(choices, "OnChange", "onchange")
     on_write = _choice_value_by_name(choices, "OnWrite", "onwrite")
-    return cycle if cycle is not None else 0, on_change if on_change is not None else 1, on_write if on_write is not None else 2
+    return (
+        cycle if cycle is not None else 0,
+        on_change if on_change is not None else 2,
+        on_write if on_write is not None else 1,
+    )
 
 
 def _build_message_info_model(message_name: str, members: List[ET.Element]) -> MessageInfoModel:
@@ -779,7 +786,7 @@ def _build_trigger_handlers(
         capl_type = _capl_member_type(signal, suffix)
 
         sig_send_type_expr = None
-        cycle_type, on_change_type, on_write_type = 0, 1, 2
+        cycle_type, on_change_type, on_write_type = 0, 2, 1
         if signal.has_sig_send_type:
             sig_send_type_expr = _sysvar(namespace, message_name, f"{signal.name}_SigSendType")
             cycle_type, on_change_type, on_write_type = _resolve_sig_send_types(signal.sig_send_type_choices)

--- a/case_editor/src/capl_generator.py
+++ b/case_editor/src/capl_generator.py
@@ -11,9 +11,10 @@ CAPL 生成器
 - 每个报文按系统变量进行模拟发送：
     * 节点/报文开关：<ns>_Node_On、<ns>_Node_Info.<sender>_MsgOn、<msg>_Info.<msg>_MsgOn/_MsgOff
     * 发送类型：当前仅实现 Cycle（MsgSendType == 0），周期取 <msg>_Info.<msg>_MsgCycleTime
-    * 信号取值优先级：use_special_value > use_inactive_value > Rv（均为原始值，写入 .raw）
+    * 信号取值优先级：special > inactive > 普通值；报文对象 msg.信号 赋物理值（CAPL 自动编码成 raw），
+      普通值用 Pv，special/inactive/counter/checksum 等 raw 码按 Factor/Offset 转成物理值再赋
     * counter 在 [min,max] 间递增到顶再回到 min
-    * checksum 使用通用参数化 CRC16（poly/init/refIn/refOut/xorOut）
+    * checksum 使用查表版 CRC16-CCITT 或 sum 校验
 - Pv/Rv 通过各自的 _Factor/_Offset 系统变量双向联动，并做防抖避免 on sysvar 互相触发死循环。
 """
 from __future__ import annotations
@@ -276,6 +277,23 @@ def _format_float(text: Optional[str], default: str) -> str:
         return default
 
 
+def _phys_expr(raw_expr: str, factor_lit: str, offset_lit: str) -> str:
+    """把一个 raw 值表达式转换为物理值表达式：raw*Factor + Offset。
+
+    报文对象的 msg.信号 赋的是物理值（CAPL 会自动编码成 raw 上总线），因此 raw 码
+    （special/inactive/counter/checksum 等）需先按各自 Factor/Offset 转成物理值。
+    当 Factor==1 且 Offset==0 时直接返回原表达式，保持输出简洁。
+    """
+    f = (factor_lit or "1").strip()
+    o = (offset_lit or "0").strip()
+    expr = raw_expr
+    if f not in ("1", "1.0"):
+        expr = f"({expr}) * ({f})"
+    if o not in ("0", "0.0"):
+        expr = f"{expr} + ({o})"
+    return expr
+
+
 def _to_capl_int_literal(value: str) -> str:
     """把 0x..., 'true'/'false', 十进制等规范化为 CAPL 整型字面量。"""
     v = value.strip().lower()
@@ -404,12 +422,13 @@ def _build_fill_function(
             continue
         lines.extend(_build_signal_assignment(namespace, message_name, signal))
 
-    # 2) counter：写当前值，再在 [min,max] 间递增/回绕
+    # 2) counter：写当前值（raw 计数转物理值），再在 [min,max] 间递增/回绕
     if has_counter:
         counter = model.get(counter_signal)
         cmin = _to_capl_number(counter.rv_min, "0")
         cmax = _to_capl_number(counter.rv_max, "255")
-        lines.append(f"  {msg}.{counter_signal} = {cnt_var};")
+        cnt_phys = _phys_expr(cnt_var, _format_float(counter.factor, "1"), _format_float(counter.offset, "0"))
+        lines.append(f"  {msg}.{counter_signal} = {cnt_phys};")
         lines.append(f"  if ({cnt_var} >= {cmax})")
         lines.append(f"    {cnt_var} = {cmin};")
         lines.append("  else")
@@ -421,8 +440,13 @@ def _build_fill_function(
     if has_checksum:
         method = (check_method or "crc16").strip().lower()
         params = check_parameters or {}
+        chk = model.get(check_signal)
+        chk_factor = _format_float(chk.factor, "1")
+        chk_offset = _format_float(chk.offset, "0")
+        crc_phys = _phys_expr("_crc", chk_factor, chk_offset)
         lines.append("")
-        lines.append(f"  {msg}.{check_signal} = 0;")
+        # 清零：物理值取 Offset 使该字段的 raw 为 0（Offset 通常为 0）。
+        lines.append(f"  {msg}.{check_signal} = {chk_offset};")
         lines.append(f"  _n = {msg}.dlc;")
         lines.append("  for (_i = 0; _i < _n; _i++)")
         lines.append(f"    _data[_i] = {msg}.byte(_i);")
@@ -435,7 +459,7 @@ def _build_fill_function(
             )
         else:  # sum 校验
             lines.append("  _crc = PROJ_Checksum(_data, _n);")
-        lines.append(f"  {msg}.{check_signal} = _crc;")
+        lines.append(f"  {msg}.{check_signal} = {crc_phys};")
 
     lines.append("}")
     lines.append("")
@@ -444,26 +468,39 @@ def _build_fill_function(
 
 def _build_signal_assignment(namespace: str, message_name: str, signal: SignalModel) -> List[str]:
     msg = _msg_var(message_name)
-    rv = _sysvar(namespace, message_name, f"{signal.name}_Rv")
-    # 报文对象的 msg.信号 即原始值(raw)，不能再加 .raw（否则 CANoe 报 invalid expression）。
+    # 报文对象的 msg.信号 赋的是物理值，CAPL 会按 DBC 自动编码成 raw 上总线。
     target = f"{msg}.{signal.name}"
-    lines: List[str] = []
+    factor_lit = _format_float(signal.factor, "1")
+    offset_lit = _format_float(signal.offset, "0")
 
+    # 普通取值用物理值 Pv；无 Pv 成员时退回用 Rv 换算成物理值。
+    if signal.has_pv:
+        normal_value = _sysvar(namespace, message_name, f"{signal.name}_Pv")
+    else:
+        rv = _sysvar(namespace, message_name, f"{signal.name}_Rv")
+        normal_value = _phys_expr(rv, factor_lit, offset_lit)
+
+    lines: List[str] = []
     branches: List[Tuple[str, str]] = []
     # special 优先级高于 inactive：需同时满足“定义了该值(has_*==1)”且“启用(use_*==1)”。
+    # special/inactive 在系统变量里是 raw 码，需转成物理值再赋给报文信号。
     if signal.has_special_value:
         has_special = _sysvar(namespace, message_name, f"{signal.name}_has_special_value")
         use_special = _sysvar(namespace, message_name, f"{signal.name}_use_special_value")
         special_value = _sysvar(namespace, message_name, f"{signal.name}_special_value")
-        branches.append((f"{has_special} == 1 && {use_special} == 1", special_value))
+        branches.append(
+            (f"{has_special} == 1 && {use_special} == 1", _phys_expr(special_value, factor_lit, offset_lit))
+        )
     if signal.has_inactive_value:
         has_inactive = _sysvar(namespace, message_name, f"{signal.name}_has_inactive_value")
         use_inactive = _sysvar(namespace, message_name, f"{signal.name}_use_inactive_value")
         inactive_value = _sysvar(namespace, message_name, f"{signal.name}_inactive_value")
-        branches.append((f"{has_inactive} == 1 && {use_inactive} == 1", inactive_value))
+        branches.append(
+            (f"{has_inactive} == 1 && {use_inactive} == 1", _phys_expr(inactive_value, factor_lit, offset_lit))
+        )
 
     if not branches:
-        lines.append(f"  {target} = {rv};")
+        lines.append(f"  {target} = {normal_value};")
         return lines
 
     for idx, (cond, value) in enumerate(branches):
@@ -471,7 +508,7 @@ def _build_signal_assignment(namespace: str, message_name: str, signal: SignalMo
         lines.append(f"  {keyword} ({cond})")
         lines.append(f"    {target} = {value};")
     lines.append("  else")
-    lines.append(f"    {target} = {rv};")
+    lines.append(f"    {target} = {normal_value};")
     return lines
 
 

--- a/case_editor/src/capl_generator.py
+++ b/case_editor/src/capl_generator.py
@@ -510,11 +510,17 @@ def _build_linkage_handlers(
         sv_pv = f"{namespace}::{message_name}.{signal.name}_Pv"
         sv_rv = f"{namespace}::{message_name}.{signal.name}_Rv"
 
-        # Pv 改变 -> 重算 Rv（Rv = round((Pv - Offset)/Factor)），并夹到 Rv 的 min/max。
+        # Pv 改变 -> 重算 Rv（Rv = 四舍五入((Pv - Offset)/Factor)），并夹到 Rv 的 min/max。
+        # CAPL 无 round()，用 (long)(x +/- 0.5) 实现四舍五入（兼容负值）。
         lines.append(f"on sysvar {sv_pv}")
         lines.append("{")
+        lines.append("  double _q;")
         lines.append("  long _newRv;")
-        lines.append(f"  _newRv = round(({pv} - ({offset_lit})) / ({factor_lit}));")
+        lines.append(f"  _q = ({pv} - ({offset_lit})) / ({factor_lit});")
+        lines.append("  if (_q >= 0)")
+        lines.append("    _newRv = (long)(_q + 0.5);")
+        lines.append("  else")
+        lines.append("    _newRv = (long)(_q - 0.5);")
         if signal.rv_min is not None and signal.rv_min != "":
             lines.append(f"  if (_newRv < {signal.rv_min})")
             lines.append(f"    _newRv = {signal.rv_min};")

--- a/case_editor/src/capl_generator.py
+++ b/case_editor/src/capl_generator.py
@@ -772,181 +772,225 @@ def _build_finish_burst_function(
     return lines
 
 
-def _build_trigger_handlers(
+def _linkage_factor_ok(signal: SignalModel) -> bool:
+    try:
+        return float(signal.factor) != 0
+    except (TypeError, ValueError):
+        return False
+
+
+def _has_burst_triggers(model: MessageModel) -> bool:
+    return model.info is not None and model.info.has_msg_send_type
+
+
+def _append_burst_trigger_lines(
+    lines: List[str],
     namespace: str,
     message_name: str,
     model: MessageModel,
     parsed: ParsedSysvar,
-    exclude: Optional[set] = None,
-) -> List[str]:
-    """为 Event / CE / IfActive / CA 生成 on sysvar 触发处理器。"""
-    exclude = exclude or set()
+    signal: SignalModel,
+    suffix: str,
+    member: str,
+) -> None:
+    """向 handler 函数体追加 burst 触发逻辑（不含 on sysvar 包装）。"""
     info = model.info
     if info is None or not info.has_msg_send_type:
-        return []
+        return
 
     send_type_expr = _info_sysvar(namespace, message_name, "_MsgSendType", parsed, str(MSG_SEND_CYCLE))
-    lines: List[str] = []
+    shadow = _shadow_var(message_name, member)
+    sv = _sysvar(namespace, message_name, member)
+    capl_type = _capl_member_type(signal, suffix)
+    sig_table = signal.sig_send_type if signal.has_sig_send_type else None
+    sig_send_type_expr = (
+        _sysvar(namespace, message_name, f"{signal.name}_SigSendType") if sig_table else None
+    )
 
-    for signal, suffix in _watchable_members(model, exclude):
-        member = f"{signal.name}{suffix}"
-        sv_path = f"{namespace}::{message_name}.{member}"
-        sv = _sysvar(namespace, message_name, member)
-        shadow = _shadow_var(message_name, member)
-        capl_type = _capl_member_type(signal, suffix)
-        sig_table = signal.sig_send_type if signal.has_sig_send_type else None
-        sig_send_type_expr = (
-            _sysvar(namespace, message_name, f"{signal.name}_SigSendType") if sig_table else None
+    inactive_cmp = None
+    if signal.has_inactive_value and suffix in ("_Pv", "_Rv"):
+        if suffix == "_Pv":
+            inactive_cmp = f"_new != ({_inactive_phys_expr(namespace, message_name, signal)})"
+        else:
+            inactive_cmp = f"_new != ({_inactive_raw_expr(namespace, message_name, signal)})"
+
+    lines.append(f"  {capl_type} _old, _new;")
+    lines.append("  long _triggered, _use_fast;")
+    lines.append(f"  _old = {shadow};")
+    lines.append(f"  _new = {sv};")
+    lines.append("  _triggered = 0;")
+    lines.append("  _use_fast = 0;")
+
+    lines.append(f"  if ({send_type_expr} == {MSG_SEND_EVENT} && _old != _new)")
+    lines.append("  {")
+    lines.append("    _triggered = 1;")
+    lines.append("    _use_fast = 0;")
+    lines.append("  }")
+
+    if inactive_cmp:
+        lines.append(
+            f"  else if ({send_type_expr} == {MSG_SEND_IF_ACTIVE} && _old != _new && ({inactive_cmp}))"
         )
-
-        inactive_cmp = None
-        if signal.has_inactive_value and suffix in ("_Pv", "_Rv"):
-            if suffix == "_Pv":
-                inactive_cmp = f"_new != ({_inactive_phys_expr(namespace, message_name, signal)})"
-            else:
-                inactive_cmp = f"_new != ({_inactive_raw_expr(namespace, message_name, signal)})"
-
-        lines.append(f"on sysvar {sv_path}")
-        lines.append("{")
-        lines.append(f"  {capl_type} _old, _new;")
-        lines.append("  long _triggered, _use_fast;")
-        lines.append(f"  _old = {shadow};")
-        lines.append(f"  _new = {sv};")
-        lines.append("  _triggered = 0;")
-        lines.append("  _use_fast = 0;")
-
-        # Event
-        lines.append(f"  if ({send_type_expr} == {MSG_SEND_EVENT} && _old != _new)")
         lines.append("  {")
         lines.append("    _triggered = 1;")
         lines.append("    _use_fast = 0;")
         lines.append("  }")
 
-        # IfActive
-        if inactive_cmp:
+    if sig_send_type_expr and sig_table:
+        if sig_table.on_change is not None:
             lines.append(
-                f"  else if ({send_type_expr} == {MSG_SEND_IF_ACTIVE} && _old != _new && ({inactive_cmp}))"
+                f"  else if ({send_type_expr} == {MSG_SEND_CE} && {sig_send_type_expr} == {sig_table.on_change}"
+                f" && _old != _new)"
             )
             lines.append("  {")
             lines.append("    _triggered = 1;")
-            lines.append("    _use_fast = 0;")
+            lines.append("    _use_fast = 1;")
             lines.append("  }")
-
-        # CE：仅当 valuetable 中解析到 OnChange / OnWrite 数值时才生成对应分支
-        if sig_send_type_expr and sig_table:
-            if sig_table.on_change is not None:
-                lines.append(
-                    f"  else if ({send_type_expr} == {MSG_SEND_CE} && {sig_send_type_expr} == {sig_table.on_change}"
-                    f" && _old != _new)"
-                )
-                lines.append("  {")
-                lines.append("    _triggered = 1;")
-                lines.append("    _use_fast = 1;")
-                lines.append("  }")
-            if sig_table.on_write is not None:
-                lines.append(
-                    f"  else if ({send_type_expr} == {MSG_SEND_CE} && {sig_send_type_expr} == {sig_table.on_write})"
-                )
-                lines.append("  {")
-                lines.append("    _triggered = 1;")
-                lines.append("    _use_fast = 1;")
-                lines.append("  }")
-
-        # CA：非 Cycle 类型信号变为非 inactive 时快速 burst
-        if inactive_cmp and sig_send_type_expr and sig_table and sig_table.cycle is not None:
+        if sig_table.on_write is not None:
             lines.append(
-                f"  else if ({send_type_expr} == {MSG_SEND_CA} && {sig_send_type_expr} != {sig_table.cycle}"
-                f" && _old != _new && ({inactive_cmp}))"
+                f"  else if ({send_type_expr} == {MSG_SEND_CE} && {sig_send_type_expr} == {sig_table.on_write})"
             )
             lines.append("  {")
             lines.append("    _triggered = 1;")
             lines.append("    _use_fast = 1;")
             lines.append("  }")
 
-        lines.append("  if (_triggered)")
+    if inactive_cmp and sig_send_type_expr and sig_table and sig_table.cycle is not None:
+        lines.append(
+            f"  else if ({send_type_expr} == {MSG_SEND_CA} && {sig_send_type_expr} != {sig_table.cycle}"
+            f" && _old != _new && ({inactive_cmp}))"
+        )
         lines.append("  {")
-        lines.append(f"    {_restore_pending_var(message_name, member)} = 1;")
-        lines.append(f"    {_restore_var(message_name, member)} = _old;")
-        lines.append(f"    {shadow} = _new;")
-        lines.append(f"    begin_burst_{message_name}(_use_fast);")
+        lines.append("    _triggered = 1;")
+        lines.append("    _use_fast = 1;")
         lines.append("  }")
-        lines.append("  else")
-        lines.append(f"    {shadow} = _new;")
-        lines.append("}")
-        lines.append("")
 
-    return lines
+    lines.append("  if (_triggered)")
+    lines.append("  {")
+    lines.append(f"    {_restore_pending_var(message_name, member)} = 1;")
+    lines.append(f"    {_restore_var(message_name, member)} = _old;")
+    lines.append(f"    {shadow} = _new;")
+    lines.append(f"    begin_burst_{message_name}(_use_fast);")
+    lines.append("  }")
+    lines.append("  else")
+    lines.append(f"    {shadow} = _new;")
 
 
-def _build_linkage_handlers(
+def _append_pv_to_rv_linkage_lines(
+    lines: List[str],
+    namespace: str,
+    message_name: str,
+    signal: SignalModel,
+) -> None:
+    """Pv 变化时同步 Rv。"""
+    pv = _sysvar(namespace, message_name, f"{signal.name}_Pv")
+    rv = _sysvar(namespace, message_name, f"{signal.name}_Rv")
+    factor_lit = _format_float(signal.factor, "1")
+    offset_lit = _format_float(signal.offset, "0")
+    lines.append("  double _q;")
+    lines.append("  long _newRv;")
+    lines.append(f"  _q = ({pv} - ({offset_lit})) / ({factor_lit});")
+    lines.append("  if (_q >= 0)")
+    lines.append("    _newRv = (long)(_q + 0.5);")
+    lines.append("  else")
+    lines.append("    _newRv = (long)(_q - 0.5);")
+    if signal.rv_min is not None and signal.rv_min != "":
+        lines.append(f"  if (_newRv < {signal.rv_min})")
+        lines.append(f"    _newRv = {signal.rv_min};")
+    if signal.rv_max is not None and signal.rv_max != "":
+        lines.append(f"  if (_newRv > {signal.rv_max})")
+        lines.append(f"    _newRv = {signal.rv_max};")
+    lines.append(f"  if (_newRv != {rv})")
+    lines.append(f"    {rv} = _newRv;")
+
+
+def _append_rv_to_pv_linkage_lines(
+    lines: List[str],
+    namespace: str,
+    message_name: str,
+    signal: SignalModel,
+) -> None:
+    """Rv 变化时同步 Pv。"""
+    pv = _sysvar(namespace, message_name, f"{signal.name}_Pv")
+    rv = _sysvar(namespace, message_name, f"{signal.name}_Rv")
+    factor_lit = _format_float(signal.factor, "1")
+    offset_lit = _format_float(signal.offset, "0")
+    lines.append("  double _newPv;")
+    lines.append(f"  _newPv = {rv} * ({factor_lit}) + ({offset_lit});")
+    lines.append(f"  if (_newPv != {pv})")
+    lines.append(f"    {pv} = _newPv;")
+
+
+def _build_merged_sysvar_handlers(
     namespace: str,
     message_name: str,
     model: MessageModel,
+    parsed: ParsedSysvar,
     exclude: Optional[set] = None,
 ) -> List[str]:
-    """为每个同时具备 Pv/Rv 的信号生成双向联动 on sysvar 处理器。
+    """为每个系统变量成员生成唯一的 on sysvar 处理器（burst 触发 + Pv/Rv 联动合并）。
 
-    换算的 Factor/Offset 直接采用系统变量文件里的常量（生成时确定），不在运行时再读取
-    _Factor/_Offset 系统变量。exclude 中的信号（如 checksum/counter，由程序自动计算、
-    不接受外部输入）不生成联动。
+    CAPL 不允许对同一 sysvar 注册多个 on sysvar，因此每个成员最多一个 handler。
     """
     exclude = exclude or set()
+    has_burst = _has_burst_triggers(model)
+    watchable = {(s.name, suf) for s, suf in _watchable_members(model, exclude)}
     lines: List[str] = []
+
     for signal in model.signals:
         if signal.name in exclude:
             continue
-        if not (signal.has_pv and signal.has_rv):
-            continue
-        try:
-            factor = float(signal.factor)
-        except (TypeError, ValueError):
-            factor = 1.0
-        try:
-            offset = float(signal.offset)
-        except (TypeError, ValueError):
-            offset = 0.0
-        # Factor 为 0 无法换算，跳过该信号的联动。
-        if factor == 0:
-            continue
 
-        pv = _sysvar(namespace, message_name, f"{signal.name}_Pv")
-        rv = _sysvar(namespace, message_name, f"{signal.name}_Rv")
-        factor_lit = _format_float(signal.factor, "1")
-        offset_lit = _format_float(signal.offset, "0")
-        sv_pv = f"{namespace}::{message_name}.{signal.name}_Pv"
-        sv_rv = f"{namespace}::{message_name}.{signal.name}_Rv"
+        linkage_ok = signal.has_pv and signal.has_rv and _linkage_factor_ok(signal)
 
-        # Pv 改变 -> 重算 Rv（Rv = 四舍五入((Pv - Offset)/Factor)），并夹到 Rv 的 min/max。
-        # CAPL 无 round()，用 (long)(x +/- 0.5) 实现四舍五入（兼容负值）。
-        lines.append(f"on sysvar {sv_pv}")
-        lines.append("{")
-        lines.append("  double _q;")
-        lines.append("  long _newRv;")
-        lines.append(f"  _q = ({pv} - ({offset_lit})) / ({factor_lit});")
-        lines.append("  if (_q >= 0)")
-        lines.append("    _newRv = (long)(_q + 0.5);")
-        lines.append("  else")
-        lines.append("    _newRv = (long)(_q - 0.5);")
-        if signal.rv_min is not None and signal.rv_min != "":
-            lines.append(f"  if (_newRv < {signal.rv_min})")
-            lines.append(f"    _newRv = {signal.rv_min};")
-        if signal.rv_max is not None and signal.rv_max != "":
-            lines.append(f"  if (_newRv > {signal.rv_max})")
-            lines.append(f"    _newRv = {signal.rv_max};")
-        lines.append(f"  if (_newRv != {rv})")
-        lines.append(f"    {rv} = _newRv;")
-        lines.append("}")
-        lines.append("")
+        if signal.has_pv:
+            member = f"{signal.name}_Pv"
+            sv_path = f"{namespace}::{message_name}.{member}"
+            body: List[str] = []
+            if has_burst and (signal.name, "_Pv") in watchable:
+                _append_burst_trigger_lines(
+                    body, namespace, message_name, model, parsed, signal, "_Pv", member
+                )
+            if linkage_ok:
+                _append_pv_to_rv_linkage_lines(body, namespace, message_name, signal)
+            if body:
+                lines.append(f"on sysvar {sv_path}")
+                lines.append("{")
+                lines.extend(body)
+                lines.append("}")
+                lines.append("")
 
-        # Rv 改变 -> 重算 Pv（Pv = Rv*Factor + Offset）
-        lines.append(f"on sysvar {sv_rv}")
-        lines.append("{")
-        lines.append("  double _newPv;")
-        lines.append(f"  _newPv = {rv} * ({factor_lit}) + ({offset_lit});")
-        lines.append(f"  if (_newPv != {pv})")
-        lines.append(f"    {pv} = _newPv;")
-        lines.append("}")
-        lines.append("")
+        if signal.has_rv:
+            member = f"{signal.name}_Rv"
+            sv_path = f"{namespace}::{message_name}.{member}"
+            body = []
+            if has_burst and (signal.name, "_Rv") in watchable:
+                _append_burst_trigger_lines(
+                    body, namespace, message_name, model, parsed, signal, "_Rv", member
+                )
+            if linkage_ok:
+                _append_rv_to_pv_linkage_lines(body, namespace, message_name, signal)
+            if body:
+                lines.append(f"on sysvar {sv_path}")
+                lines.append("{")
+                lines.extend(body)
+                lines.append("}")
+                lines.append("")
+
+        if has_burst and signal.has_special_value and (signal.name, "_use_special_value") in watchable:
+            member = f"{signal.name}_use_special_value"
+            sv_path = f"{namespace}::{message_name}.{member}"
+            body = []
+            _append_burst_trigger_lines(
+                body, namespace, message_name, model, parsed, signal, "_use_special_value", member
+            )
+            if body:
+                lines.append(f"on sysvar {sv_path}")
+                lines.append("{")
+                lines.extend(body)
+                lines.append("}")
+                lines.append("")
+
     return lines
 
 
@@ -1050,18 +1094,7 @@ def _build_can_file(
                 msg_cfg.get("check_parameters", {}),
             )
         )
-        if model.info and model.info.has_msg_send_type:
-            out.extend(_build_trigger_handlers(namespace, name, model, parsed, exclude))
-
-    # Pv/Rv 联动（跳过 checksum/counter 这类程序自动计算、不接受外部输入的信号）
-    for msg_cfg, model in messages:
-        exclude = set()
-        if msg_cfg.get("has_validation", False):
-            for key in ("check_signal", "counter_signal"):
-                sig = msg_cfg.get(key, "")
-                if sig:
-                    exclude.add(sig)
-        out.extend(_build_linkage_handlers(namespace, model.name, model, exclude))
+        out.extend(_build_merged_sysvar_handlers(namespace, name, model, parsed, exclude))
 
     return "\n".join(out) + "\n"
 

--- a/case_editor/src/capl_generator.py
+++ b/case_editor/src/capl_generator.py
@@ -55,6 +55,20 @@ _WATCHABLE_SUFFIXES = ("_Pv", "_Rv", "_use_special_value")
 
 
 @dataclass
+class SigSendTypeTable:
+    """从 .vsysvar 解析得到的 SigSendType valuetable 及其语义映射。
+
+    数值完全来自 valuetable，生成 CAPL 时只使用此处记录的值，不写死默认映射。
+    若 valuetable 中缺少某项，对应字段为 None，生成器跳过依赖该类型的触发分支。
+    """
+    choices: Dict[int, str] = field(default_factory=dict)
+    cycle: Optional[int] = None
+    on_write: Optional[int] = None
+    on_change: Optional[int] = None
+    event: Optional[int] = None
+
+
+@dataclass
 class SignalModel:
     """报文中的单个信号及其系统变量元数据。"""
     name: str
@@ -69,7 +83,7 @@ class SignalModel:
     has_pv: bool = False
     has_rv: bool = False
     has_sig_send_type: bool = False
-    sig_send_type_choices: Dict[int, str] = field(default_factory=dict)
+    sig_send_type: SigSendTypeTable = field(default_factory=SigSendTypeTable)
 
 
 @dataclass
@@ -147,18 +161,14 @@ def _choice_value_by_name(choices: Dict[int, str], *names: str) -> Optional[int]
     return None
 
 
-def _resolve_sig_send_types(choices: Dict[int, str]) -> Tuple[int, int, int]:
-    """解析 SigSendType valuetable，返回 (cycle, on_change, on_write) 的数值。
-
-    若 valuetable 缺失，默认与常见 DBC 定义一致：Cycle=0, OnWrite=1, OnChange=2。
-    """
-    cycle = _choice_value_by_name(choices, "Cycle", "Cyclic", "cycle", "cyclic")
-    on_change = _choice_value_by_name(choices, "OnChange", "onchange")
-    on_write = _choice_value_by_name(choices, "OnWrite", "onwrite")
-    return (
-        cycle if cycle is not None else 0,
-        on_change if on_change is not None else 2,
-        on_write if on_write is not None else 1,
+def _build_sig_send_type_table(choices: Dict[int, str]) -> SigSendTypeTable:
+    """根据 valuetable 建立 SigSendType 语义到数值的映射（解析阶段一次性完成）。"""
+    return SigSendTypeTable(
+        choices=dict(choices),
+        cycle=_choice_value_by_name(choices, "Cycle", "Cyclic", "cycle", "cyclic"),
+        on_write=_choice_value_by_name(choices, "OnWrite", "onwrite"),
+        on_change=_choice_value_by_name(choices, "OnChange", "onchange"),
+        event=_choice_value_by_name(choices, "Event", "event"),
     )
 
 
@@ -295,7 +305,7 @@ def _apply_member(signal: SignalModel, suffix: str, member: ET.Element) -> None:
         signal.inactive_raw = member.get("startValue")
     elif suffix == "_SigSendType":
         signal.has_sig_send_type = True
-        signal.sig_send_type_choices = _parse_value_table(member)
+        signal.sig_send_type = _build_sig_send_type_table(_parse_value_table(member))
 
 
 def _read_text_any_encoding(path: str) -> str:
@@ -784,12 +794,10 @@ def _build_trigger_handlers(
         sv = _sysvar(namespace, message_name, member)
         shadow = _shadow_var(message_name, member)
         capl_type = _capl_member_type(signal, suffix)
-
-        sig_send_type_expr = None
-        cycle_type, on_change_type, on_write_type = 0, 2, 1
-        if signal.has_sig_send_type:
-            sig_send_type_expr = _sysvar(namespace, message_name, f"{signal.name}_SigSendType")
-            cycle_type, on_change_type, on_write_type = _resolve_sig_send_types(signal.sig_send_type_choices)
+        sig_table = signal.sig_send_type if signal.has_sig_send_type else None
+        sig_send_type_expr = (
+            _sysvar(namespace, message_name, f"{signal.name}_SigSendType") if sig_table else None
+        )
 
         inactive_cmp = None
         if signal.has_inactive_value and suffix in ("_Pv", "_Rv"):
@@ -824,28 +832,30 @@ def _build_trigger_handlers(
             lines.append("    _use_fast = 0;")
             lines.append("  }")
 
-        # CE
-        if sig_send_type_expr:
-            lines.append(
-                f"  else if ({send_type_expr} == {MSG_SEND_CE} && {sig_send_type_expr} == {on_change_type}"
-                f" && _old != _new)"
-            )
-            lines.append("  {")
-            lines.append("    _triggered = 1;")
-            lines.append("    _use_fast = 1;")
-            lines.append("  }")
-            lines.append(
-                f"  else if ({send_type_expr} == {MSG_SEND_CE} && {sig_send_type_expr} == {on_write_type})"
-            )
-            lines.append("  {")
-            lines.append("    _triggered = 1;")
-            lines.append("    _use_fast = 1;")
-            lines.append("  }")
+        # CE：仅当 valuetable 中解析到 OnChange / OnWrite 数值时才生成对应分支
+        if sig_send_type_expr and sig_table:
+            if sig_table.on_change is not None:
+                lines.append(
+                    f"  else if ({send_type_expr} == {MSG_SEND_CE} && {sig_send_type_expr} == {sig_table.on_change}"
+                    f" && _old != _new)"
+                )
+                lines.append("  {")
+                lines.append("    _triggered = 1;")
+                lines.append("    _use_fast = 1;")
+                lines.append("  }")
+            if sig_table.on_write is not None:
+                lines.append(
+                    f"  else if ({send_type_expr} == {MSG_SEND_CE} && {sig_send_type_expr} == {sig_table.on_write})"
+                )
+                lines.append("  {")
+                lines.append("    _triggered = 1;")
+                lines.append("    _use_fast = 1;")
+                lines.append("  }")
 
-        # CA
-        if inactive_cmp and sig_send_type_expr:
+        # CA：非 Cycle 类型信号变为非 inactive 时快速 burst
+        if inactive_cmp and sig_send_type_expr and sig_table and sig_table.cycle is not None:
             lines.append(
-                f"  else if ({send_type_expr} == {MSG_SEND_CA} && {sig_send_type_expr} != {cycle_type}"
+                f"  else if ({send_type_expr} == {MSG_SEND_CA} && {sig_send_type_expr} != {sig_table.cycle}"
                 f" && _old != _new && ({inactive_cmp}))"
             )
             lines.append("  {")

--- a/case_editor/src/capl_generator.py
+++ b/case_editor/src/capl_generator.py
@@ -783,6 +783,16 @@ def _has_burst_triggers(model: MessageModel) -> bool:
     return model.info is not None and model.info.has_msg_send_type
 
 
+def _append_burst_trigger_decls(
+    lines: List[str],
+    signal: SignalModel,
+    suffix: str,
+) -> None:
+    capl_type = _capl_member_type(signal, suffix)
+    lines.append(f"  {capl_type} _old, _new;")
+    lines.append("  long _triggered, _use_fast;")
+
+
 def _append_burst_trigger_lines(
     lines: List[str],
     namespace: str,
@@ -792,16 +802,15 @@ def _append_burst_trigger_lines(
     signal: SignalModel,
     suffix: str,
     member: str,
-) -> None:
-    """向 handler 函数体追加 burst 触发逻辑（不含 on sysvar 包装）。"""
+) -> bool:
+    """向 handler 追加 burst 触发语句（不含局部变量声明）。返回是否生成了 burst 逻辑。"""
     info = model.info
     if info is None or not info.has_msg_send_type:
-        return
+        return False
 
     send_type_expr = _info_sysvar(namespace, message_name, "_MsgSendType", parsed, str(MSG_SEND_CYCLE))
     shadow = _shadow_var(message_name, member)
     sv = _sysvar(namespace, message_name, member)
-    capl_type = _capl_member_type(signal, suffix)
     sig_table = signal.sig_send_type if signal.has_sig_send_type else None
     sig_send_type_expr = (
         _sysvar(namespace, message_name, f"{signal.name}_SigSendType") if sig_table else None
@@ -814,8 +823,6 @@ def _append_burst_trigger_lines(
         else:
             inactive_cmp = f"_new != ({_inactive_raw_expr(namespace, message_name, signal)})"
 
-    lines.append(f"  {capl_type} _old, _new;")
-    lines.append("  long _triggered, _use_fast;")
     lines.append(f"  _old = {shadow};")
     lines.append(f"  _new = {sv};")
     lines.append("  _triggered = 0;")
@@ -874,6 +881,12 @@ def _append_burst_trigger_lines(
     lines.append("  }")
     lines.append("  else")
     lines.append(f"    {shadow} = _new;")
+    return True
+
+
+def _append_pv_to_rv_linkage_decls(lines: List[str]) -> None:
+    lines.append("  double _q;")
+    lines.append("  long _newRv;")
 
 
 def _append_pv_to_rv_linkage_lines(
@@ -887,8 +900,6 @@ def _append_pv_to_rv_linkage_lines(
     rv = _sysvar(namespace, message_name, f"{signal.name}_Rv")
     factor_lit = _format_float(signal.factor, "1")
     offset_lit = _format_float(signal.offset, "0")
-    lines.append("  double _q;")
-    lines.append("  long _newRv;")
     lines.append(f"  _q = ({pv} - ({offset_lit})) / ({factor_lit});")
     lines.append("  if (_q >= 0)")
     lines.append("    _newRv = (long)(_q + 0.5);")
@@ -904,6 +915,10 @@ def _append_pv_to_rv_linkage_lines(
     lines.append(f"    {rv} = _newRv;")
 
 
+def _append_rv_to_pv_linkage_decls(lines: List[str]) -> None:
+    lines.append("  double _newPv;")
+
+
 def _append_rv_to_pv_linkage_lines(
     lines: List[str],
     namespace: str,
@@ -915,7 +930,6 @@ def _append_rv_to_pv_linkage_lines(
     rv = _sysvar(namespace, message_name, f"{signal.name}_Rv")
     factor_lit = _format_float(signal.factor, "1")
     offset_lit = _format_float(signal.offset, "0")
-    lines.append("  double _newPv;")
     lines.append(f"  _newPv = {rv} * ({factor_lit}) + ({offset_lit});")
     lines.append(f"  if (_newPv != {pv})")
     lines.append(f"    {pv} = _newPv;")
@@ -946,48 +960,64 @@ def _build_merged_sysvar_handlers(
         if signal.has_pv:
             member = f"{signal.name}_Pv"
             sv_path = f"{namespace}::{message_name}.{member}"
-            body: List[str] = []
-            if has_burst and (signal.name, "_Pv") in watchable:
+            decls: List[str] = []
+            stmts: List[str] = []
+            want_burst = has_burst and (signal.name, "_Pv") in watchable
+            if want_burst:
+                _append_burst_trigger_decls(decls, signal, "_Pv")
+            if linkage_ok:
+                _append_pv_to_rv_linkage_decls(decls)
+            if want_burst:
                 _append_burst_trigger_lines(
-                    body, namespace, message_name, model, parsed, signal, "_Pv", member
+                    stmts, namespace, message_name, model, parsed, signal, "_Pv", member
                 )
             if linkage_ok:
-                _append_pv_to_rv_linkage_lines(body, namespace, message_name, signal)
-            if body:
+                _append_pv_to_rv_linkage_lines(stmts, namespace, message_name, signal)
+            if decls:
                 lines.append(f"on sysvar {sv_path}")
                 lines.append("{")
-                lines.extend(body)
+                lines.extend(decls)
+                lines.extend(stmts)
                 lines.append("}")
                 lines.append("")
 
         if signal.has_rv:
             member = f"{signal.name}_Rv"
             sv_path = f"{namespace}::{message_name}.{member}"
-            body = []
-            if has_burst and (signal.name, "_Rv") in watchable:
+            decls = []
+            stmts = []
+            want_burst = has_burst and (signal.name, "_Rv") in watchable
+            if want_burst:
+                _append_burst_trigger_decls(decls, signal, "_Rv")
+            if linkage_ok:
+                _append_rv_to_pv_linkage_decls(decls)
+            if want_burst:
                 _append_burst_trigger_lines(
-                    body, namespace, message_name, model, parsed, signal, "_Rv", member
+                    stmts, namespace, message_name, model, parsed, signal, "_Rv", member
                 )
             if linkage_ok:
-                _append_rv_to_pv_linkage_lines(body, namespace, message_name, signal)
-            if body:
+                _append_rv_to_pv_linkage_lines(stmts, namespace, message_name, signal)
+            if decls:
                 lines.append(f"on sysvar {sv_path}")
                 lines.append("{")
-                lines.extend(body)
+                lines.extend(decls)
+                lines.extend(stmts)
                 lines.append("}")
                 lines.append("")
 
         if has_burst and signal.has_special_value and (signal.name, "_use_special_value") in watchable:
             member = f"{signal.name}_use_special_value"
             sv_path = f"{namespace}::{message_name}.{member}"
-            body = []
-            _append_burst_trigger_lines(
-                body, namespace, message_name, model, parsed, signal, "_use_special_value", member
-            )
-            if body:
+            decls = []
+            stmts = []
+            _append_burst_trigger_decls(decls, signal, "_use_special_value")
+            if _append_burst_trigger_lines(
+                stmts, namespace, message_name, model, parsed, signal, "_use_special_value", member
+            ):
                 lines.append(f"on sysvar {sv_path}")
                 lines.append("{")
-                lines.extend(body)
+                lines.extend(decls)
+                lines.extend(stmts)
                 lines.append("}")
                 lines.append("")
 

--- a/case_editor/src/capl_generator.py
+++ b/case_editor/src/capl_generator.py
@@ -409,7 +409,7 @@ def _build_fill_function(
         counter = model.get(counter_signal)
         cmin = _to_capl_number(counter.rv_min, "0")
         cmax = _to_capl_number(counter.rv_max, "255")
-        lines.append(f"  {msg}.{counter_signal}.raw = {cnt_var};")
+        lines.append(f"  {msg}.{counter_signal} = {cnt_var};")
         lines.append(f"  if ({cnt_var} >= {cmax})")
         lines.append(f"    {cnt_var} = {cmin};")
         lines.append("  else")
@@ -422,7 +422,7 @@ def _build_fill_function(
         method = (check_method or "crc16").strip().lower()
         params = check_parameters or {}
         lines.append("")
-        lines.append(f"  {msg}.{check_signal}.raw = 0;")
+        lines.append(f"  {msg}.{check_signal} = 0;")
         lines.append(f"  _n = {msg}.dlc;")
         lines.append("  for (_i = 0; _i < _n; _i++)")
         lines.append(f"    _data[_i] = {msg}.byte(_i);")
@@ -435,7 +435,7 @@ def _build_fill_function(
             )
         else:  # sum 校验
             lines.append("  _crc = PROJ_Checksum(_data, _n);")
-        lines.append(f"  {msg}.{check_signal}.raw = _crc;")
+        lines.append(f"  {msg}.{check_signal} = _crc;")
 
     lines.append("}")
     lines.append("")
@@ -445,7 +445,8 @@ def _build_fill_function(
 def _build_signal_assignment(namespace: str, message_name: str, signal: SignalModel) -> List[str]:
     msg = _msg_var(message_name)
     rv = _sysvar(namespace, message_name, f"{signal.name}_Rv")
-    target = f"{msg}.{signal.name}.raw"
+    # 报文对象的 msg.信号 即原始值(raw)，不能再加 .raw（否则 CANoe 报 invalid expression）。
+    target = f"{msg}.{signal.name}"
     lines: List[str] = []
 
     branches: List[Tuple[str, str]] = []

--- a/case_editor/src/capl_generator.py
+++ b/case_editor/src/capl_generator.py
@@ -472,14 +472,23 @@ def _build_signal_assignment(namespace: str, message_name: str, signal: SignalMo
     return lines
 
 
-def _build_linkage_handlers(namespace: str, message_name: str, model: MessageModel) -> List[str]:
+def _build_linkage_handlers(
+    namespace: str,
+    message_name: str,
+    model: MessageModel,
+    exclude: Optional[set] = None,
+) -> List[str]:
     """为每个同时具备 Pv/Rv 的信号生成双向联动 on sysvar 处理器。
 
     换算的 Factor/Offset 直接采用系统变量文件里的常量（生成时确定），不在运行时再读取
-    _Factor/_Offset 系统变量。
+    _Factor/_Offset 系统变量。exclude 中的信号（如 checksum/counter，由程序自动计算、
+    不接受外部输入）不生成联动。
     """
+    exclude = exclude or set()
     lines: List[str] = []
     for signal in model.signals:
+        if signal.name in exclude:
+            continue
         if not (signal.has_pv and signal.has_rv):
             continue
         try:
@@ -593,9 +602,15 @@ def _build_can_file(
             )
         )
 
-    # Pv/Rv 联动
+    # Pv/Rv 联动（跳过 checksum/counter 这类程序自动计算、不接受外部输入的信号）
     for msg_cfg, model in messages:
-        out.extend(_build_linkage_handlers(namespace, model.name, model))
+        exclude = set()
+        if msg_cfg.get("has_validation", False):
+            for key in ("check_signal", "counter_signal"):
+                sig = msg_cfg.get(key, "")
+                if sig:
+                    exclude.add(sig)
+        out.extend(_build_linkage_handlers(namespace, model.name, model, exclude))
 
     return "\n".join(out) + "\n"
 

--- a/case_editor/src/capl_generator.py
+++ b/case_editor/src/capl_generator.py
@@ -450,14 +450,17 @@ def _build_signal_assignment(namespace: str, message_name: str, signal: SignalMo
     lines: List[str] = []
 
     branches: List[Tuple[str, str]] = []
+    # special 优先级高于 inactive：需同时满足“定义了该值(has_*==1)”且“启用(use_*==1)”。
     if signal.has_special_value:
+        has_special = _sysvar(namespace, message_name, f"{signal.name}_has_special_value")
         use_special = _sysvar(namespace, message_name, f"{signal.name}_use_special_value")
         special_value = _sysvar(namespace, message_name, f"{signal.name}_special_value")
-        branches.append((f"{use_special} == 1", special_value))
+        branches.append((f"{has_special} == 1 && {use_special} == 1", special_value))
     if signal.has_inactive_value:
+        has_inactive = _sysvar(namespace, message_name, f"{signal.name}_has_inactive_value")
         use_inactive = _sysvar(namespace, message_name, f"{signal.name}_use_inactive_value")
         inactive_value = _sysvar(namespace, message_name, f"{signal.name}_inactive_value")
-        branches.append((f"{use_inactive} == 1", inactive_value))
+        branches.append((f"{has_inactive} == 1 && {use_inactive} == 1", inactive_value))
 
     if not branches:
         lines.append(f"  {target} = {rv};")

--- a/case_editor/src/capl_generator.py
+++ b/case_editor/src/capl_generator.py
@@ -19,7 +19,6 @@ CAPL 生成器
 from __future__ import annotations
 
 import json
-import os
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple

--- a/case_editor/src/capl_generator.py
+++ b/case_editor/src/capl_generator.py
@@ -360,6 +360,50 @@ def resolve_channel(dbc_path: str, channel_mapping: Dict[str, int]) -> int:
     return channel_mapping.get(Path(dbc_path.replace("\\", "/")).name.lower(), 1)
 
 
+def resolve_dbc_path(dbc_path: str, project_path: Path) -> Optional[Path]:
+    """解析 DBC 文件绝对路径（支持绝对路径、相对项目路径、CANoe/dbc_file 下文件名）。"""
+    if not dbc_path:
+        return None
+    normalized = dbc_path.replace("\\", "/")
+    direct = Path(normalized)
+    if direct.is_file():
+        return direct
+    under_project = project_path / normalized
+    if under_project.is_file():
+        return under_project
+    by_name = project_path / "CANoe" / "dbc_file" / Path(normalized).name
+    if by_name.is_file():
+        return by_name
+    return None
+
+
+def load_message_frame_ids(dbc_path: str, project_path: Path) -> Dict[str, int]:
+    """从 DBC 读取 {报文名: frame_id}，用于生成 CAPL 的 message 声明。"""
+    resolved = resolve_dbc_path(dbc_path, project_path)
+    if resolved is None:
+        return {}
+    try:
+        import cantools
+
+        db = cantools.database.load_file(str(resolved))
+    except Exception as exc:
+        print(f"[capl_generator] 警告：无法解析 DBC {resolved}: {exc}")
+        return {}
+    return {msg.name: int(msg.frame_id) for msg in db.messages}
+
+
+def _message_decl(message_name: str, frame_id: Optional[int]) -> str:
+    """生成 CAPL message 变量声明。
+
+    优先使用 DBC 中的 CAN ID（如 message 0x293 msg_...），避免报文名里含 0x
+    （如 CIC_0x293）时被 CAPL 词法解析成十六进制字面量而编译失败。
+    """
+    var = _msg_var(message_name)
+    if frame_id is not None:
+        return f"  message 0x{frame_id:X} {var};"
+    return f"  message {message_name} {var};"
+
+
 # ----------------------------------------------------------------------------
 # CAPL 代码片段生成
 # ----------------------------------------------------------------------------
@@ -1030,6 +1074,7 @@ def _build_can_file(
     channel: int,
     messages: List[Tuple[Dict[str, Any], MessageModel]],
     parsed: "ParsedSysvar",
+    frame_ids: Optional[Dict[str, int]] = None,
 ) -> str:
     """生成单个发送节点的 .can 文件内容。"""
     namespace = dbc_name
@@ -1043,12 +1088,20 @@ def _build_can_file(
     out.append("}")
     out.append("")
 
+    frame_ids = frame_ids or {}
+
     # variables 块
     out.append("variables")
     out.append("{")
     for msg_cfg, model in messages:
         name = model.name
-        out.append(f"  message {name} {_msg_var(name)};")
+        frame_id = frame_ids.get(name)
+        if frame_id is None and frame_ids:
+            print(
+                f"[capl_generator] 警告：DBC 中未找到报文 {name!r}，"
+                f"将使用符号名声明 message（若编译失败请检查 DBC 或报文名）"
+            )
+        out.append(_message_decl(name, frame_id))
         out.append(f"  msTimer tmr_{name};")
         if _counter_enabled(msg_cfg, model):
             out.append(f"  long cnt_{name};")
@@ -1242,6 +1295,7 @@ def generate_capl(config: Dict[str, Any], project_path) -> List[str]:
         dbc_name = dbc_config.get("dbc_name", "")
         dbc_path = dbc_config.get("dbc_path", "")
         channel = resolve_channel(dbc_path, channel_mapping)
+        frame_ids = load_message_frame_ids(dbc_path, project_path)
 
         for sender in dbc_config.get("senders", []):
             sender_node = sender.get("sender_node", "")
@@ -1257,7 +1311,9 @@ def generate_capl(config: Dict[str, Any], project_path) -> List[str]:
             if not messages:
                 continue
 
-            content = _build_can_file(dbc_name, sender_node, channel, messages, parsed)
+            content = _build_can_file(
+                dbc_name, sender_node, channel, messages, parsed, frame_ids
+            )
             file_path = output_dir / f"{dbc_name}_{sender_node}.can"
             file_path.write_text(content, encoding="utf-8")
             generated.append(str(file_path))

--- a/case_editor/src/capl_generator.py
+++ b/case_editor/src/capl_generator.py
@@ -248,6 +248,14 @@ def _msg_var(message_name: str) -> str:
     return f"msg_{message_name}"
 
 
+def _counter_enabled(msg_cfg: Dict[str, Any], model: MessageModel) -> bool:
+    """该报文是否需要 counter（启用校验且 counter 信号存在于报文中）。"""
+    if not msg_cfg.get("has_validation", False):
+        return False
+    counter_signal = msg_cfg.get("counter_signal", "")
+    return bool(counter_signal) and model.get(counter_signal) is not None
+
+
 def _info_var(message_name: str) -> str:
     return f"{message_name}_Info"
 
@@ -360,27 +368,36 @@ def _build_fill_function(
     namespace: str,
     message_name: str,
     model: MessageModel,
+    has_validation: bool,
     counter_signal: str,
     check_signal: str,
     check_method: str,
     check_parameters: Dict[str, Any],
 ) -> List[str]:
-    """生成填充并发送一条报文的函数体（设置信号、counter、checksum）。"""
+    """生成填充并发送一条报文的函数体（设置信号、counter、checksum）。
+
+    仅当 has_validation 为真时才生成 counter 递增与 checksum 计算；否则只填普通信号。
+    """
     msg = _msg_var(message_name)
     cnt_var = f"cnt_{message_name}"
+
+    # 未启用校验的报文不处理 counter/checksum。
+    if not has_validation:
+        counter_signal = ""
+        check_signal = ""
+
+    has_counter = bool(counter_signal) and model.get(counter_signal) is not None
+    has_checksum = bool(check_signal) and model.get(check_signal) is not None
+    need_crc_buf = has_checksum  # 仅在需要 checksum 时声明 CRC 缓冲变量
+
     lines: List[str] = []
     lines.append(f"void fill_{message_name}()")
     lines.append("{")
-    lines.append("  byte _data[64];")
-    lines.append("  long _i, _n;")
-    lines.append("  dword _crc;")
-    lines.append("")
-
-    has_counter = bool(counter_signal) and model.get(counter_signal) is not None
-    # 若 checksum 与 counter 是同一个信号（DBC 配置异常），优先按 checksum 处理。
-    has_checksum = bool(check_signal) and model.get(check_signal) is not None
-    if has_counter and has_checksum and counter_signal == check_signal:
-        has_counter = False
+    if need_crc_buf:
+        lines.append("  byte _data[64];")
+        lines.append("  long _i, _n;")
+        lines.append("  dword _crc;")
+        lines.append("")
 
     # 1) 普通信号：special > inactive > Rv
     for signal in model.signals:
@@ -538,7 +555,8 @@ def _build_can_file(
         name = model.name
         out.append(f"  message {name} {_msg_var(name)};")
         out.append(f"  msTimer tmr_{name};")
-        out.append(f"  long cnt_{name};")
+        if _counter_enabled(msg_cfg, model):
+            out.append(f"  long cnt_{name};")
     out.append("}")
     out.append("")
 
@@ -547,11 +565,11 @@ def _build_can_file(
     out.append("{")
     for msg_cfg, model in messages:
         name = model.name
-        counter_signal = msg_cfg.get("counter_signal", "")
-        counter = model.get(counter_signal) if counter_signal else None
-        cmin = _to_capl_number(counter.rv_min, "0") if counter else "0"
         out.append(f"  {_msg_var(name)}.CAN = {channel};")
-        out.append(f"  cnt_{name} = {cmin};")
+        if _counter_enabled(msg_cfg, model):
+            counter = model.get(msg_cfg.get("counter_signal", ""))
+            cmin = _to_capl_number(counter.rv_min, "0")
+            out.append(f"  cnt_{name} = {cmin};")
         out.append(f"  arm_{name}();")
     out.append("}")
     out.append("")
@@ -567,6 +585,7 @@ def _build_can_file(
                 namespace,
                 name,
                 model,
+                bool(msg_cfg.get("has_validation", False)),
                 msg_cfg.get("counter_signal", ""),
                 msg_cfg.get("check_signal", ""),
                 msg_cfg.get("check_method", "crc16"),

--- a/case_editor/src/capl_generator.py
+++ b/case_editor/src/capl_generator.py
@@ -1,0 +1,660 @@
+"""
+CAPL 生成器
+
+根据 generate_capl 的配置（按发送节点组织）以及项目里的系统变量文件（.vsysvar），
+为每个发送节点生成一个独立的 CANoe CAPL 节点文件（.can）。
+
+设计要点：
+- 信号清单与元数据（Factor/Offset、Rv 的 min/max、是否有 special/inactive）全部从
+  .vsysvar 文件解析得到，运行时不依赖原始 DBC。
+- CAN 通道号从项目的 project.json -> canoe.dbc_files 读取（channel 为 0 基，实际通道 = channel + 1）。
+- 每个报文按系统变量进行模拟发送：
+    * 节点/报文开关：<ns>_Node_On、<ns>_Node_Info.<sender>_MsgOn、<msg>_Info.<msg>_MsgOn/_MsgOff
+    * 发送类型：当前仅实现 Cycle（MsgSendType == 0），周期取 <msg>_Info.<msg>_MsgCycleTime
+    * 信号取值优先级：use_special_value > use_inactive_value > Rv（均为原始值，写入 .raw）
+    * counter 在 [min,max] 间递增到顶再回到 min
+    * checksum 使用通用参数化 CRC16（poly/init/refIn/refOut/xorOut）
+- Pv/Rv 通过各自的 _Factor/_Offset 系统变量双向联动，并做防抖避免 on sysvar 互相触发死循环。
+"""
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+from xml.etree import ElementTree as ET
+
+
+# ----------------------------------------------------------------------------
+# 数据模型
+# ----------------------------------------------------------------------------
+
+# 单个信号在 .vsysvar 报文结构里的成员后缀（带前导下划线）。
+# 注意：匹配时必须按“长后缀优先”，否则 _special_value 会错误命中 _has_special_value。
+_SIGNAL_SUFFIXES = [
+    "_has_special_value",
+    "_use_special_value",
+    "_has_inactive_value",
+    "_use_inactive_value",
+    "_special_value",
+    "_inactive_value",
+    "_Factor",
+    "_Offset",
+    "_Pv",
+    "_Rv",
+]
+
+
+@dataclass
+class SignalModel:
+    """报文中的单个信号及其系统变量元数据。"""
+    name: str
+    factor: str = "1"
+    offset: str = "0"
+    rv_min: Optional[str] = None
+    rv_max: Optional[str] = None
+    pv_is_int: bool = True
+    has_special_value: bool = False   # 是否存在 _special_value 成员
+    has_inactive_value: bool = False  # 是否存在 _inactive_value 成员
+    has_pv: bool = False
+    has_rv: bool = False
+
+
+@dataclass
+class MessageModel:
+    """一条报文：名称 + 有序信号列表。"""
+    name: str
+    signals: List[SignalModel] = field(default_factory=list)
+    signal_index: Dict[str, SignalModel] = field(default_factory=dict)
+
+    def get(self, signal_name: str) -> Optional[SignalModel]:
+        return self.signal_index.get(signal_name)
+
+
+@dataclass
+class ParsedSysvar:
+    """.vsysvar 解析结果。"""
+    messages: Dict[str, MessageModel] = field(default_factory=dict)
+    variable_names: set = field(default_factory=set)   # 所有 variable 的名称
+    member_names: set = field(default_factory=set)      # 所有 structMember 的名称
+
+
+# ----------------------------------------------------------------------------
+# .vsysvar 解析
+# ----------------------------------------------------------------------------
+
+def _split_signal_member(member_name: str) -> Optional[Tuple[str, str]]:
+    """把成员名拆为 (信号名, 后缀)。无法识别返回 None。"""
+    for suffix in _SIGNAL_SUFFIXES:
+        if member_name.endswith(suffix):
+            return member_name[: -len(suffix)], suffix
+    return None
+
+
+def parse_vsysvar(vsysvar_path: str) -> ParsedSysvar:
+    """解析 .vsysvar。
+
+    报文名取自报文数据结构对应的 variable 名（如 IPB_0x10C）。
+    同时收集所有 variable 名与 structMember 名，便于生成时判断门控变量是否存在。
+    """
+    content = _read_text_any_encoding(vsysvar_path)
+    root = ET.fromstring(content)
+
+    result = ParsedSysvar()
+
+    # 1) 收集所有 struct 定义：struct 名(小写) -> 有序成员元素列表
+    structs: Dict[str, List[ET.Element]] = {}
+    for struct in root.iter("struct"):
+        struct_name = struct.get("name", "")
+        if not struct_name:
+            continue
+        members = list(struct.findall("./structMember"))
+        structs[struct_name.lower()] = members
+        for member in members:
+            name = member.get("name", "")
+            if name:
+                result.member_names.add(name)
+
+    for variable in root.iter("variable"):
+        name = variable.get("name", "")
+        if name:
+            result.variable_names.add(name)
+
+    # 2) 找到所有“报文数据变量”：type=struct 且 structDefinition 指向的 struct 名
+    #    等于变量名的小写（报文数据结构命名规则为 message.name.lower()）。
+    for variable in root.iter("variable"):
+        if variable.get("type") != "struct":
+            continue
+        var_name = variable.get("name", "")
+        struct_def = variable.get("structDefinition", "")
+        if not var_name or not struct_def:
+            continue
+        struct_simple = struct_def.split("::")[-1].lower()
+        # 仅认报文数据结构：struct 名 == 变量名小写；排除 *_info / *_node_info 等
+        if struct_simple != var_name.lower():
+            continue
+        members = structs.get(struct_simple)
+        if members is None:
+            continue
+        model = _build_message_model(var_name, members)
+        if model.signals:
+            result.messages[var_name] = model
+    return result
+
+
+def _build_message_model(message_name: str, members: List[ET.Element]) -> MessageModel:
+    model = MessageModel(name=message_name)
+    node_member = f"{message_name}_node"
+
+    for member in members:
+        member_name = member.get("name", "")
+        if not member_name or member_name == node_member:
+            continue  # 跳过发送节点字符串成员
+        split = _split_signal_member(member_name)
+        if split is None:
+            continue
+        signal_name, suffix = split
+        signal = model.signal_index.get(signal_name)
+        if signal is None:
+            signal = SignalModel(name=signal_name)
+            model.signal_index[signal_name] = signal
+            model.signals.append(signal)
+        _apply_member(signal, suffix, member)
+
+    return model
+
+
+def _apply_member(signal: SignalModel, suffix: str, member: ET.Element) -> None:
+    if suffix == "_Pv":
+        signal.has_pv = True
+        signal.pv_is_int = member.get("type", "int") == "int"
+    elif suffix == "_Rv":
+        signal.has_rv = True
+        signal.rv_min = member.get("minValue")
+        signal.rv_max = member.get("maxValue")
+    elif suffix == "_Factor":
+        signal.factor = member.get("startValue", "1")
+    elif suffix == "_Offset":
+        signal.offset = member.get("startValue", "0")
+    elif suffix == "_special_value":
+        signal.has_special_value = True
+    elif suffix == "_inactive_value":
+        signal.has_inactive_value = True
+
+
+def _read_text_any_encoding(path: str) -> str:
+    with open(path, "rb") as fh:
+        data = fh.read()
+    for encoding in ("utf-8-sig", "utf-8", "gbk", "gb18030", "utf-16", "latin-1"):
+        try:
+            return data.decode(encoding)
+        except (UnicodeDecodeError, UnicodeError):
+            continue
+    return data.decode("utf-8", errors="replace")
+
+
+# ----------------------------------------------------------------------------
+# 项目通道映射
+# ----------------------------------------------------------------------------
+
+def load_channel_mapping(project_path: Path) -> Dict[str, int]:
+    """从 project.json 读取 {dbc文件名(小写): 实际CAN通道号}。
+
+    project.json 里 canoe.dbc_files 的 channel 为 0 基，实际通道号 = channel + 1。
+    """
+    mapping: Dict[str, int] = {}
+    project_json = project_path / "project.json"
+    if not project_json.exists():
+        return mapping
+    try:
+        with open(project_json, "r", encoding="utf-8") as fh:
+            config = json.load(fh)
+    except Exception:
+        return mapping
+
+    dbc_files = (config.get("canoe", {}) or {}).get("dbc_files", {}) or {}
+    if isinstance(dbc_files, dict):
+        entries = dbc_files.values()
+    else:  # 兼容旧的列表格式
+        entries = [{"path": p, "channel": 0} for p in dbc_files]
+
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        path = entry.get("path", "")
+        if not path:
+            continue
+        channel = entry.get("channel", 0) or 0
+        mapping[Path(path).name.lower()] = int(channel) + 1
+    return mapping
+
+
+def resolve_channel(dbc_path: str, channel_mapping: Dict[str, int]) -> int:
+    """按文件名匹配通道；找不到默认返回 1。"""
+    return channel_mapping.get(Path(dbc_path.replace("\\", "/")).name.lower(), 1)
+
+
+# ----------------------------------------------------------------------------
+# CAPL 代码片段生成
+# ----------------------------------------------------------------------------
+
+def _sysvar(namespace: str, variable: str, member: Optional[str] = None) -> str:
+    base = f"@{namespace}::{variable}"
+    return f"{base}.{member}" if member else base
+
+
+def _msg_var(message_name: str) -> str:
+    return f"msg_{message_name}"
+
+
+def _info_var(message_name: str) -> str:
+    return f"{message_name}_Info"
+
+
+def _to_capl_number(text: Optional[str], default: str) -> str:
+    if text is None or text == "":
+        return default
+    return text
+
+
+def _to_capl_int_literal(value: str) -> str:
+    """把 0x..., 'true'/'false', 十进制等规范化为 CAPL 整型字面量。"""
+    v = value.strip().lower()
+    if v in ("true", "1"):
+        return "1"
+    if v in ("false", "0"):
+        return "0"
+    if v.startswith("0x"):
+        return value.strip()
+    try:
+        return str(int(float(value)))
+    except ValueError:
+        return "0"
+
+
+# CRC 通用库（参数化 CRC16）。生成一次，被各 .can 文件 include。
+CHECKSUM_LIB = """/*@!Encoding:65001*/
+/*
+ * 通用参数化 CRC16 计算库（自动生成，请勿手改）。
+ * 通过 poly / init / refIn / refOut / xorOut 支持常见 CRC16 变体。
+ */
+
+byte ReflectByte(byte value)
+{
+  byte result;
+  long i;
+  result = 0;
+  for (i = 0; i < 8; i++)
+  {
+    if (value & (1 << i))
+      result |= (byte)(1 << (7 - i));
+  }
+  return result;
+}
+
+dword Reflect16(dword value)
+{
+  dword result;
+  long i;
+  result = 0;
+  for (i = 0; i < 16; i++)
+  {
+    if (value & ((dword)1 << i))
+      result |= ((dword)1 << (15 - i));
+  }
+  return result & 0xFFFF;
+}
+
+dword ComputeCrc16(byte data[], long len, dword poly, dword init, long refIn, long refOut, dword xorOut)
+{
+  dword crc;
+  long i, b;
+  byte cur;
+
+  crc = init & 0xFFFF;
+  for (i = 0; i < len; i++)
+  {
+    cur = data[i];
+    if (refIn)
+      cur = ReflectByte(cur);
+    crc = crc ^ ((dword)cur << 8);
+    for (b = 0; b < 8; b++)
+    {
+      if (crc & 0x8000)
+        crc = ((crc << 1) ^ poly) & 0xFFFF;
+      else
+        crc = (crc << 1) & 0xFFFF;
+    }
+  }
+  if (refOut)
+    crc = Reflect16(crc);
+  crc = (crc ^ xorOut) & 0xFFFF;
+  return crc & 0xFFFF;
+}
+"""
+
+
+def _build_fill_function(
+    namespace: str,
+    message_name: str,
+    model: MessageModel,
+    counter_signal: str,
+    check_signal: str,
+    check_method: str,
+    check_parameters: Dict[str, Any],
+) -> List[str]:
+    """生成填充并发送一条报文的函数体（设置信号、counter、checksum）。"""
+    msg = _msg_var(message_name)
+    cnt_var = f"cnt_{message_name}"
+    lines: List[str] = []
+    lines.append(f"void fill_{message_name}()")
+    lines.append("{")
+    lines.append("  byte _data[64];")
+    lines.append("  long _i, _n;")
+    lines.append("  dword _crc;")
+    lines.append("")
+
+    has_counter = bool(counter_signal) and model.get(counter_signal) is not None
+    # 若 checksum 与 counter 是同一个信号（DBC 配置异常），优先按 checksum 处理。
+    has_checksum = bool(check_signal) and model.get(check_signal) is not None
+    if has_counter and has_checksum and counter_signal == check_signal:
+        has_counter = False
+
+    # 1) 普通信号：special > inactive > Rv
+    for signal in model.signals:
+        if signal.name in (counter_signal, check_signal):
+            continue
+        lines.extend(_build_signal_assignment(namespace, message_name, signal))
+
+    # 2) counter：写当前值，再在 [min,max] 间递增/回绕
+    if has_counter:
+        counter = model.get(counter_signal)
+        cmin = _to_capl_number(counter.rv_min, "0")
+        cmax = _to_capl_number(counter.rv_max, "255")
+        lines.append(f"  {msg}.{counter_signal}.raw = {cnt_var};")
+        lines.append(f"  if ({cnt_var} >= {cmax})")
+        lines.append(f"    {cnt_var} = {cmin};")
+        lines.append("  else")
+        lines.append(f"    {cnt_var} = {cnt_var} + 1;")
+
+    # 3) checksum：先清零再对整条报文数据计算 CRC
+    if has_checksum:
+        params = check_parameters or {}
+        poly = _to_capl_int_literal(str(params.get("poly", "0x1021")))
+        init = _to_capl_int_literal(str(params.get("init", "0xFFFF")))
+        ref_in = _to_capl_int_literal(str(params.get("refIn", "false")))
+        ref_out = _to_capl_int_literal(str(params.get("refOut", "false")))
+        xor_out = _to_capl_int_literal(str(params.get("xorOut", "0x0000")))
+        lines.append("")
+        lines.append(f"  {msg}.{check_signal}.raw = 0;")
+        lines.append(f"  _n = {msg}.dlc;")
+        lines.append("  for (_i = 0; _i < _n; _i++)")
+        lines.append(f"    _data[_i] = {msg}.byte(_i);")
+        lines.append(
+            f"  _crc = ComputeCrc16(_data, _n, {poly}, {init}, {ref_in}, {ref_out}, {xor_out});"
+        )
+        lines.append(f"  {msg}.{check_signal}.raw = _crc;")
+
+    lines.append("}")
+    lines.append("")
+    return lines
+
+
+def _build_signal_assignment(namespace: str, message_name: str, signal: SignalModel) -> List[str]:
+    msg = _msg_var(message_name)
+    rv = _sysvar(namespace, message_name, f"{signal.name}_Rv")
+    target = f"{msg}.{signal.name}.raw"
+    lines: List[str] = []
+
+    branches: List[Tuple[str, str]] = []
+    if signal.has_special_value:
+        use_special = _sysvar(namespace, message_name, f"{signal.name}_use_special_value")
+        special_value = _sysvar(namespace, message_name, f"{signal.name}_special_value")
+        branches.append((f"{use_special} == 1", special_value))
+    if signal.has_inactive_value:
+        use_inactive = _sysvar(namespace, message_name, f"{signal.name}_use_inactive_value")
+        inactive_value = _sysvar(namespace, message_name, f"{signal.name}_inactive_value")
+        branches.append((f"{use_inactive} == 1", inactive_value))
+
+    if not branches:
+        lines.append(f"  {target} = {rv};")
+        return lines
+
+    for idx, (cond, value) in enumerate(branches):
+        keyword = "if" if idx == 0 else "else if"
+        lines.append(f"  {keyword} ({cond})")
+        lines.append(f"    {target} = {value};")
+    lines.append("  else")
+    lines.append(f"    {target} = {rv};")
+    return lines
+
+
+def _build_linkage_handlers(namespace: str, message_name: str, model: MessageModel) -> List[str]:
+    """为每个同时具备 Pv/Rv 的信号生成双向联动 on sysvar 处理器。"""
+    lines: List[str] = []
+    for signal in model.signals:
+        if not (signal.has_pv and signal.has_rv):
+            continue
+        pv = _sysvar(namespace, message_name, f"{signal.name}_Pv")
+        rv = _sysvar(namespace, message_name, f"{signal.name}_Rv")
+        factor = _sysvar(namespace, message_name, f"{signal.name}_Factor")
+        offset = _sysvar(namespace, message_name, f"{signal.name}_Offset")
+        sv_pv = f"{namespace}::{message_name}.{signal.name}_Pv"
+        sv_rv = f"{namespace}::{message_name}.{signal.name}_Rv"
+
+        # Pv 改变 -> 重算 Rv
+        lines.append(f"on sysvar {sv_pv}")
+        lines.append("{")
+        lines.append("  double _f, _o;")
+        lines.append("  long _newRv;")
+        lines.append(f"  _f = {factor};")
+        lines.append(f"  _o = {offset};")
+        lines.append("  if (_f == 0) return;")
+        lines.append(f"  _newRv = round(({pv} - _o) / _f);")
+        lines.append(f"  if (_newRv != {rv})")
+        lines.append(f"    {rv} = _newRv;")
+        lines.append("}")
+        lines.append("")
+
+        # Rv 改变 -> 重算 Pv
+        lines.append(f"on sysvar {sv_rv}")
+        lines.append("{")
+        lines.append("  double _f, _o, _newPv;")
+        lines.append(f"  _f = {factor};")
+        lines.append(f"  _o = {offset};")
+        lines.append(f"  _newPv = {rv} * _f + _o;")
+        lines.append(f"  if (_newPv != {pv})")
+        lines.append(f"    {pv} = _newPv;")
+        lines.append("}")
+        lines.append("")
+    return lines
+
+
+def _build_can_file(
+    dbc_name: str,
+    sender_node: str,
+    channel: int,
+    messages: List[Tuple[Dict[str, Any], MessageModel]],
+    parsed: "ParsedSysvar",
+) -> str:
+    """生成单个发送节点的 .can 文件内容。"""
+    namespace = dbc_name
+    out: List[str] = []
+    out.append("/*@!Encoding:65001*/")
+    out.append(f"/* 自动生成：{dbc_name} 网络中 {sender_node} 节点的报文模拟发送 */")
+    out.append("")
+    out.append("includes")
+    out.append("{")
+    out.append('  #include "checksum_lib.cin"')
+    out.append("}")
+    out.append("")
+
+    # variables 块
+    out.append("variables")
+    out.append("{")
+    for msg_cfg, model in messages:
+        name = model.name
+        out.append(f"  message {name} {_msg_var(name)};")
+        out.append(f"  msTimer tmr_{name};")
+        out.append(f"  long cnt_{name};")
+    out.append("}")
+    out.append("")
+
+    # on start：设置通道、初始化 counter、装载定时器
+    out.append("on start")
+    out.append("{")
+    for msg_cfg, model in messages:
+        name = model.name
+        counter_signal = msg_cfg.get("counter_signal", "")
+        counter = model.get(counter_signal) if counter_signal else None
+        cmin = _to_capl_number(counter.rv_min, "0") if counter else "0"
+        out.append(f"  {_msg_var(name)}.CAN = {channel};")
+        out.append(f"  cnt_{name} = {cmin};")
+        out.append(f"  arm_{name}();")
+    out.append("}")
+    out.append("")
+
+    # 每条报文：装载函数 + 定时器事件 + 发送函数 + 填充函数
+    for msg_cfg, model in messages:
+        name = model.name
+        out.extend(_build_arm_function(namespace, name, parsed))
+        out.extend(_build_timer_handler(name))
+        out.extend(_build_send_function(namespace, dbc_name, sender_node, name, parsed))
+        out.extend(
+            _build_fill_function(
+                namespace,
+                name,
+                model,
+                msg_cfg.get("counter_signal", ""),
+                msg_cfg.get("check_signal", ""),
+                msg_cfg.get("check_method", "crc16"),
+                msg_cfg.get("check_parameters", {}),
+            )
+        )
+
+    # Pv/Rv 联动
+    for msg_cfg, model in messages:
+        out.extend(_build_linkage_handlers(namespace, model.name, model))
+
+    return "\n".join(out) + "\n"
+
+
+def _build_arm_function(namespace: str, message_name: str, parsed: "ParsedSysvar") -> List[str]:
+    info = _info_var(message_name)
+    if info in parsed.variable_names:
+        cycle_expr = _sysvar(namespace, info, f"{message_name}_MsgCycleTime")
+    else:
+        cycle_expr = "10"  # 无 *_Info 时使用默认周期
+    return [
+        f"void arm_{message_name}()",
+        "{",
+        "  long _ct;",
+        f"  _ct = {cycle_expr};",
+        "  if (_ct <= 0)",
+        "    _ct = 10;",
+        f"  setTimer(tmr_{message_name}, _ct);",
+        "}",
+        "",
+    ]
+
+
+def _build_timer_handler(message_name: str) -> List[str]:
+    return [
+        f"on timer tmr_{message_name}",
+        "{",
+        f"  send_{message_name}();",
+        f"  arm_{message_name}();",
+        "}",
+        "",
+    ]
+
+
+def _build_send_function(
+    namespace: str,
+    dbc_name: str,
+    sender_node: str,
+    message_name: str,
+    parsed: "ParsedSysvar",
+) -> List[str]:
+    info = _info_var(message_name)
+    node_info = f"{dbc_name}_Node_Info"
+    node_on = f"{dbc_name}_Node_On"
+    lines = [f"void send_{message_name}()", "{"]
+    # 节点级总开关（仅当系统变量存在时才生成）
+    if node_on in parsed.variable_names:
+        lines.append(f"  if ({_sysvar(namespace, node_on)} != 1) return;")
+    # 发送节点开关（仅当 <sender>_MsgOn 成员存在时才生成）
+    if f"{sender_node}_MsgOn" in parsed.member_names:
+        lines.append(f"  if ({_sysvar(namespace, node_info, sender_node + '_MsgOn')} != 1) return;")
+    # 报文开关（仅当 <msg>_Info 存在时才生成）
+    if info in parsed.variable_names:
+        lines.append(f"  if ({_sysvar(namespace, info, message_name + '_MsgOn')} != 1) return;")
+        lines.append(f"  if ({_sysvar(namespace, info, message_name + '_MsgOff')} == 1) return;")
+        # 仅 Cycle 类型（MsgSendType == 0）
+        lines.append(f"  if ({_sysvar(namespace, info, message_name + '_MsgSendType')} != 0) return;")
+    lines.append(f"  fill_{message_name}();")
+    lines.append(f"  output({_msg_var(message_name)});")
+    lines.append("}")
+    lines.append("")
+    return lines
+
+
+# ----------------------------------------------------------------------------
+# 入口
+# ----------------------------------------------------------------------------
+
+def generate_capl(config: Dict[str, Any], project_path) -> List[str]:
+    """根据配置为每个发送节点生成 .can 文件。
+
+    Args:
+        config: 见模块/项目说明，按发送节点组织，含 selected_system_variable_file。
+        project_path: 项目根路径（用于读取 project.json 通道映射与写出文件）。
+
+    Returns:
+        List[str]: 生成的 .can 文件路径列表（同时会生成共享的 checksum_lib.cin）。
+    """
+    project_path = Path(project_path)
+    output_dir = project_path / "CANoe" / "capl"
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # 共享 CRC 库
+    lib_path = output_dir / "checksum_lib.cin"
+    lib_path.write_text(CHECKSUM_LIB, encoding="utf-8")
+
+    # 解析系统变量文件
+    sysvar_file = config.get("selected_system_variable_file", "")
+    if sysvar_file and Path(sysvar_file).exists():
+        parsed = parse_vsysvar(sysvar_file)
+    else:
+        raise FileNotFoundError(f"系统变量文件不存在或未配置: {sysvar_file!r}")
+    messages_by_name = parsed.messages
+
+    channel_mapping = load_channel_mapping(project_path)
+
+    generated: List[str] = []
+    for dbc_config in config.get("dbc_configs", []):
+        dbc_name = dbc_config.get("dbc_name", "")
+        dbc_path = dbc_config.get("dbc_path", "")
+        channel = resolve_channel(dbc_path, channel_mapping)
+
+        for sender in dbc_config.get("senders", []):
+            sender_node = sender.get("sender_node", "")
+            messages: List[Tuple[Dict[str, Any], MessageModel]] = []
+            for msg_cfg in sender.get("messages", []):
+                msg_name = msg_cfg.get("message_name", "")
+                model = messages_by_name.get(msg_name)
+                if model is None:
+                    print(f"[capl_generator] 警告：系统变量文件中未找到报文 {msg_name}，已跳过")
+                    continue
+                messages.append((msg_cfg, model))
+
+            if not messages:
+                continue
+
+            content = _build_can_file(dbc_name, sender_node, channel, messages, parsed)
+            file_path = output_dir / f"{dbc_name}_{sender_node}.can"
+            file_path.write_text(content, encoding="utf-8")
+            generated.append(str(file_path))
+
+    return generated

--- a/case_editor/src/capl_generator.py
+++ b/case_editor/src/capl_generator.py
@@ -258,6 +258,17 @@ def _to_capl_number(text: Optional[str], default: str) -> str:
     return text
 
 
+def _format_float(text: Optional[str], default: str) -> str:
+    """把 Factor/Offset 文本规范化为 CAPL 浮点字面量。"""
+    if text is None or text == "":
+        return default
+    try:
+        float(text)
+        return text.strip()
+    except ValueError:
+        return default
+
+
 def _to_capl_int_literal(value: str) -> str:
     """把 0x..., 'true'/'false', 十进制等规范化为 CAPL 整型字面量。"""
     v = value.strip().lower()
@@ -273,64 +284,74 @@ def _to_capl_int_literal(value: str) -> str:
         return "0"
 
 
-# CRC 通用库（参数化 CRC16）。生成一次，被各 .can 文件 include。
+# 校验库（自动生成，被各 .can 文件 include）。
+# - 查表版 CRC16-CCITT：poly 0x1021 / init 0xFFFF / xorOut 0x0000，可由参数变更。
+# - sum 校验：逐字节求和后取反（^0xFF）。
 CHECKSUM_LIB = """/*@!Encoding:65001*/
 /*
- * 通用参数化 CRC16 计算库（自动生成，请勿手改）。
- * 通过 poly / init / refIn / refOut / xorOut 支持常见 CRC16 变体。
+ * 报文校验库（自动生成，请勿手改）。
+ * 1) PROJ_CRC16_CCITT：查表法 CRC16-CCITT，poly/init/xorOut 可由调用参数控制。
+ * 2) PROJ_Checksum    ：逐字节求和后取反（sum ^ 0xFF）。
  */
 
-byte ReflectByte(byte value)
+variables
 {
-  byte result;
-  long i;
-  result = 0;
-  for (i = 0; i < 8; i++)
-  {
-    if (value & (1 << i))
-      result |= (byte)(1 << (7 - i));
-  }
-  return result;
+  word gCrc1021Table[256];
+  byte gCrcTableReady = 0;
+  dword gCrcTablePoly = 0;
 }
 
-dword Reflect16(dword value)
+void BuildCrc16Table(dword poly)
 {
-  dword result;
-  long i;
-  result = 0;
-  for (i = 0; i < 16; i++)
-  {
-    if (value & ((dword)1 << i))
-      result |= ((dword)1 << (15 - i));
-  }
-  return result & 0xFFFF;
-}
-
-dword ComputeCrc16(byte data[], long len, dword poly, dword init, long refIn, long refOut, dword xorOut)
-{
-  dword crc;
   long i, b;
-  byte cur;
+  word crc;
 
-  crc = init & 0xFFFF;
-  for (i = 0; i < len; i++)
+  for (i = 0; i < 256; i++)
   {
-    cur = data[i];
-    if (refIn)
-      cur = ReflectByte(cur);
-    crc = crc ^ ((dword)cur << 8);
+    crc = (word)((i << 8) & 0xFFFF);
     for (b = 0; b < 8; b++)
     {
       if (crc & 0x8000)
-        crc = ((crc << 1) ^ poly) & 0xFFFF;
+        crc = (word)(((crc << 1) ^ poly) & 0xFFFF);
       else
-        crc = (crc << 1) & 0xFFFF;
+        crc = (word)((crc << 1) & 0xFFFF);
     }
+    gCrc1021Table[i] = crc;
   }
-  if (refOut)
-    crc = Reflect16(crc);
-  crc = (crc ^ xorOut) & 0xFFFF;
-  return crc & 0xFFFF;
+  gCrcTablePoly = poly;
+  gCrcTableReady = 1;
+}
+
+// 查表法 CRC16-CCITT（非反射）。init/poly/xorOut 由调用方传入，便于按报文配置变更。
+word PROJ_CRC16_CCITT(byte data[], long len, dword init, dword poly, dword xorOut)
+{
+  word crc;
+  long i;
+  byte idx;
+
+  // 多项式变化时（或首次调用）重建查找表。
+  if (!gCrcTableReady || gCrcTablePoly != poly)
+    BuildCrc16Table(poly);
+
+  crc = (word)(init & 0xFFFF);
+  for (i = 0; i < len; i++)
+  {
+    idx = (byte)(((crc >> 8) ^ data[i]) & 0xFF);
+    crc = (word)(((crc << 8) ^ gCrc1021Table[idx]) & 0xFFFF);
+  }
+  return (word)((crc ^ xorOut) & 0xFFFF);
+}
+
+// sum 校验：逐字节求和后取反。
+byte PROJ_Checksum(byte data[], long len)
+{
+  byte sum;
+  long i;
+
+  sum = 0;
+  for (i = 0; i < len; i++)
+    sum = (byte)((sum + data[i]) & 0xFF);
+  return (byte)(sum ^ 0xFF);
 }
 """
 
@@ -378,22 +399,26 @@ def _build_fill_function(
         lines.append("  else")
         lines.append(f"    {cnt_var} = {cnt_var} + 1;")
 
-    # 3) checksum：先清零再对整条报文数据计算 CRC
+    # 3) checksum：先清零，再对整条报文数据计算校验值。
+    #    覆盖范围当前为“整条报文数据字节（校验字段已清零）”。如需排除 counter / 含 DataID，
+    #    仅需调整下面读取 _data 的范围与 _n。
     if has_checksum:
+        method = (check_method or "crc16").strip().lower()
         params = check_parameters or {}
-        poly = _to_capl_int_literal(str(params.get("poly", "0x1021")))
-        init = _to_capl_int_literal(str(params.get("init", "0xFFFF")))
-        ref_in = _to_capl_int_literal(str(params.get("refIn", "false")))
-        ref_out = _to_capl_int_literal(str(params.get("refOut", "false")))
-        xor_out = _to_capl_int_literal(str(params.get("xorOut", "0x0000")))
         lines.append("")
         lines.append(f"  {msg}.{check_signal}.raw = 0;")
         lines.append(f"  _n = {msg}.dlc;")
         lines.append("  for (_i = 0; _i < _n; _i++)")
         lines.append(f"    _data[_i] = {msg}.byte(_i);")
-        lines.append(
-            f"  _crc = ComputeCrc16(_data, _n, {poly}, {init}, {ref_in}, {ref_out}, {xor_out});"
-        )
+        if "crc" in method:
+            poly = _to_capl_int_literal(str(params.get("poly", "0x1021")))
+            init = _to_capl_int_literal(str(params.get("init", "0xFFFF")))
+            xor_out = _to_capl_int_literal(str(params.get("xorOut", "0x0000")))
+            lines.append(
+                f"  _crc = PROJ_CRC16_CCITT(_data, _n, {init}, {poly}, {xor_out});"
+            )
+        else:  # sum 校验
+            lines.append("  _crc = PROJ_Checksum(_data, _n);")
         lines.append(f"  {msg}.{check_signal}.raw = _crc;")
 
     lines.append("}")
@@ -431,39 +456,49 @@ def _build_signal_assignment(namespace: str, message_name: str, signal: SignalMo
 
 
 def _build_linkage_handlers(namespace: str, message_name: str, model: MessageModel) -> List[str]:
-    """为每个同时具备 Pv/Rv 的信号生成双向联动 on sysvar 处理器。"""
+    """为每个同时具备 Pv/Rv 的信号生成双向联动 on sysvar 处理器。
+
+    换算的 Factor/Offset 直接采用系统变量文件里的常量（生成时确定），不在运行时再读取
+    _Factor/_Offset 系统变量。
+    """
     lines: List[str] = []
     for signal in model.signals:
         if not (signal.has_pv and signal.has_rv):
             continue
+        try:
+            factor = float(signal.factor)
+        except (TypeError, ValueError):
+            factor = 1.0
+        try:
+            offset = float(signal.offset)
+        except (TypeError, ValueError):
+            offset = 0.0
+        # Factor 为 0 无法换算，跳过该信号的联动。
+        if factor == 0:
+            continue
+
         pv = _sysvar(namespace, message_name, f"{signal.name}_Pv")
         rv = _sysvar(namespace, message_name, f"{signal.name}_Rv")
-        factor = _sysvar(namespace, message_name, f"{signal.name}_Factor")
-        offset = _sysvar(namespace, message_name, f"{signal.name}_Offset")
+        factor_lit = _format_float(signal.factor, "1")
+        offset_lit = _format_float(signal.offset, "0")
         sv_pv = f"{namespace}::{message_name}.{signal.name}_Pv"
         sv_rv = f"{namespace}::{message_name}.{signal.name}_Rv"
 
-        # Pv 改变 -> 重算 Rv
+        # Pv 改变 -> 重算 Rv（Rv = round((Pv - Offset)/Factor)）
         lines.append(f"on sysvar {sv_pv}")
         lines.append("{")
-        lines.append("  double _f, _o;")
         lines.append("  long _newRv;")
-        lines.append(f"  _f = {factor};")
-        lines.append(f"  _o = {offset};")
-        lines.append("  if (_f == 0) return;")
-        lines.append(f"  _newRv = round(({pv} - _o) / _f);")
+        lines.append(f"  _newRv = round(({pv} - ({offset_lit})) / ({factor_lit}));")
         lines.append(f"  if (_newRv != {rv})")
         lines.append(f"    {rv} = _newRv;")
         lines.append("}")
         lines.append("")
 
-        # Rv 改变 -> 重算 Pv
+        # Rv 改变 -> 重算 Pv（Pv = Rv*Factor + Offset）
         lines.append(f"on sysvar {sv_rv}")
         lines.append("{")
-        lines.append("  double _f, _o, _newPv;")
-        lines.append(f"  _f = {factor};")
-        lines.append(f"  _o = {offset};")
-        lines.append(f"  _newPv = {rv} * _f + _o;")
+        lines.append("  double _newPv;")
+        lines.append(f"  _newPv = {rv} * ({factor_lit}) + ({offset_lit});")
         lines.append(f"  if (_newPv != {pv})")
         lines.append(f"    {pv} = _newPv;")
         lines.append("}")

--- a/case_editor/src/fixtures/control_ipb_sample.vsysvar
+++ b/case_editor/src/fixtures/control_ipb_sample.vsysvar
@@ -1,0 +1,50 @@
+<?xml version='1.0' encoding='utf-8'?>
+<systemvariables version="4">
+  <namespace name="" comment="" interface="">
+    <namespace name="Control" comment="" interface="">
+      <struct name="control_node_info" isUnion="False" definedBinaryLayout="False" comment="">
+        <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="IPB_MsgOn" comment="" bitcount="32" isSigned="false" encoding="65001" type="int" startValue="1" minValue="0" maxValue="1" />
+      </struct>
+      <variable anlyzLocal="2" readOnly="false" valueSequence="false" unit="" name="Control_Node_Info" comment="" bitcount="32" isSigned="true" encoding="65001" type="struct" structDefinition="Control::control_node_info" />
+      <struct name="ipb_0x10c_info" isUnion="False" definedBinaryLayout="False" comment="">
+        <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="IPB_0x10C_MsgOn" comment="" bitcount="32" isSigned="false" encoding="65001" type="int" startValue="1" minValue="0" maxValue="1" />
+        <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="IPB_0x10C_MsgOff" comment="" bitcount="32" isSigned="false" encoding="65001" type="int" startValue="0" minValue="0" maxValue="1" />
+        <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="IPB_0x10C_MsgSendType" comment="" bitcount="32" isSigned="false" encoding="65001" type="int" startValue="0" minValue="0" maxValue="5">
+          <valuetable name="IPB_0x10C_MsgSendTypeVt" definesMinMax="false">
+            <valuetableentry value="0" lowerBound="0" upperBound="0" description="Cycle" displayString="Cycle" />
+            <valuetableentry value="1" lowerBound="1" upperBound="1" description="Event" displayString="Event" />
+            <valuetableentry value="2" lowerBound="2" upperBound="2" description="IfActive" displayString="IfActive" />
+            <valuetableentry value="3" lowerBound="3" upperBound="3" description="CE" displayString="CE" />
+            <valuetableentry value="4" lowerBound="4" upperBound="4" description="CA" displayString="CA" />
+            <valuetableentry value="5" lowerBound="5" upperBound="5" description="NoMsgSendType" displayString="NoMsgSendType" />
+          </valuetable>
+        </structMember>
+        <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="IPB_0x10C_MsgCycleTime" comment="" bitcount="32" isSigned="false" encoding="65001" type="int" startValue="10" minValue="0" maxValue="65535" />
+        <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="IPB_0x10C_WrongCRCFlag" comment="" bitcount="32" isSigned="false" encoding="65001" type="int" startValue="0" minValue="0" maxValue="1" />
+        <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="IPB_0x10C_WrongCounterFlag" comment="" bitcount="32" isSigned="false" encoding="65001" type="int" startValue="0" minValue="0" maxValue="1" />
+      </struct>
+      <variable anlyzLocal="2" readOnly="false" valueSequence="false" unit="" name="IPB_0x10C_Info" comment="" bitcount="192" isSigned="true" encoding="65001" type="struct" structDefinition="Control::ipb_0x10c_info" />
+      <struct name="ipb_0x10c" isUnion="False" definedBinaryLayout="False" comment="">
+        <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="Vehicle_speed_Pv" comment="Vehicle_speed" bitcount="64" isSigned="false" encoding="65001" type="float" startValue="0" minValue="0" maxValue="281.4625" />
+        <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="Vehicle_speed_Rv" comment="Vehicle_speed" bitcount="32" isSigned="false" encoding="65001" type="int" startValue="0" minValue="0" maxValue="4094" />
+        <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="Vehicle_speed_Factor" comment="Vehicle_speed" bitcount="64" isSigned="false" encoding="65001" type="float" startValue="0.06875" />
+        <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="Vehicle_speed_Offset" comment="Vehicle_speed" bitcount="64" isSigned="false" encoding="65001" type="float" startValue="0" />
+        <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="Vehicle_speed_has_special_value" comment="" bitcount="32" isSigned="false" encoding="65001" type="int" startValue="0" minValue="0" maxValue="1" />
+        <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="Vehicle_speed_use_special_value" comment="" bitcount="32" isSigned="false" encoding="65001" type="int" startValue="0" minValue="0" maxValue="1" />
+        <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="Vehicle_speed_has_inactive_value" comment="" bitcount="32" isSigned="false" encoding="65001" type="int" startValue="1" minValue="0" maxValue="1" />
+        <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="Vehicle_speed_use_inactive_value" comment="" bitcount="32" isSigned="false" encoding="65001" type="int" startValue="0" minValue="0" maxValue="1" />
+        <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="Vehicle_speed_inactive_value" comment="" bitcount="32" isSigned="false" encoding="65001" type="int" startValue="4095" />
+        <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="Vehicle_speed_SigSendType" comment="" bitcount="32" isSigned="false" encoding="65001" type="int" startValue="0" minValue="0" maxValue="4">
+          <valuetable name="Vehicle_speed_SigSendTypeVt" definesMinMax="false">
+            <valuetableentry value="0" lowerBound="0" upperBound="0" description="Cycle" displayString="Cycle" />
+            <valuetableentry value="1" lowerBound="1" upperBound="1" description="OnWrite" displayString="OnWrite" />
+            <valuetableentry value="2" lowerBound="2" upperBound="2" description="OnChange" displayString="OnChange" />
+            <valuetableentry value="3" lowerBound="3" upperBound="3" description="Event" displayString="Event" />
+            <valuetableentry value="4" lowerBound="4" upperBound="4" description="NoSigSendType" displayString="NoSigSendType" />
+          </valuetable>
+        </structMember>
+      </struct>
+      <variable anlyzLocal="2" readOnly="false" valueSequence="false" unit="" name="IPB_0x10C" comment="" bitcount="512" isSigned="true" encoding="65001" type="struct" structDefinition="Control::ipb_0x10c" />
+    </namespace>
+  </namespace>
+</systemvariables>

--- a/case_editor/src/test_capl_generator.py
+++ b/case_editor/src/test_capl_generator.py
@@ -24,6 +24,10 @@ VSYSVAR = """<?xml version='1.0' encoding='utf-8'?>
         <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="IPB_0x10C_MsgOff" comment="" bitcount="32" isSigned="false" encoding="65001" type="int" startValue="0" minValue="0" maxValue="1" />
         <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="IPB_0x10C_MsgSendType" comment="" bitcount="32" isSigned="false" encoding="65001" type="int" startValue="0" minValue="0" maxValue="5" />
         <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="IPB_0x10C_MsgCycleTime" comment="" bitcount="32" isSigned="false" encoding="65001" type="int" startValue="10" minValue="0" maxValue="65535" />
+        <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="IPB_0x10C_MsgCycleTimeFast" comment="" bitcount="32" isSigned="false" encoding="65001" type="int" startValue="5" minValue="0" maxValue="65535" />
+        <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="IPB_0x10C_MsgNrOfRepetition" comment="" bitcount="32" isSigned="false" encoding="65001" type="int" startValue="3" minValue="0" maxValue="255" />
+        <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="IPB_0x10C_WrongCRCFlag" comment="" bitcount="32" isSigned="false" encoding="65001" type="int" startValue="0" minValue="0" maxValue="1" />
+        <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="IPB_0x10C_WrongCounterFlag" comment="" bitcount="32" isSigned="false" encoding="65001" type="int" startValue="0" minValue="0" maxValue="1" />
       </struct>
       <variable anlyzLocal="2" readOnly="false" valueSequence="false" unit="" name="IPB_0x10C_Info" comment="" bitcount="128" isSigned="true" encoding="65001" type="struct" structDefinition="control::ipb_0x10c_info" />
       <struct name="ipb_0x10c" isUnion="False" definedBinaryLayout="False" comment="">
@@ -45,6 +49,13 @@ VSYSVAR = """<?xml version='1.0' encoding='utf-8'?>
         <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="Vehicle_speed_has_inactive_value" comment="" bitcount="32" isSigned="false" encoding="65001" type="int" startValue="1" minValue="0" maxValue="1" />
         <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="Vehicle_speed_use_inactive_value" comment="" bitcount="32" isSigned="false" encoding="65001" type="int" startValue="0" minValue="0" maxValue="1" />
         <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="Vehicle_speed_inactive_value" comment="" bitcount="32" isSigned="false" encoding="65001" type="int" startValue="4095" />
+        <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="Vehicle_speed_SigSendType" comment="" bitcount="32" isSigned="false" encoding="65001" type="int" startValue="0" minValue="0" maxValue="2">
+          <valuetable defineMinMax="false" defineStartValue="false">
+            <valuetableentry value="0" description="Cycle" />
+            <valuetableentry value="1" description="OnChange" />
+            <valuetableentry value="2" description="OnWrite" />
+          </valuetable>
+        </structMember>
       </struct>
       <variable anlyzLocal="2" readOnly="false" valueSequence="false" unit="" name="IPB_0x10C" comment="" bitcount="512" isSigned="true" encoding="65001" type="struct" structDefinition="control::ipb_0x10c" />
       <struct name="ipb_0x200" isUnion="False" definedBinaryLayout="False" comment="">
@@ -132,10 +143,18 @@ def main():
 
     print("\n=== generate_capl ===")
     files = generate_capl(config, base)
+    capl_text = ""
     for f in files:
         print("generated:", f)
+        capl_text = Path(f).read_text(encoding="utf-8")
         print("-" * 60)
-        print(Path(f).read_text(encoding="utf-8"))
+        print(capl_text)
+
+    assert "use_inactive_value" not in capl_text
+    assert "WrongCRCFlag" in capl_text
+    assert "WrongCounterFlag" in capl_text
+    assert "MsgNrOfRepetition" in capl_text
+    print("\n=== assertions passed ===")
 
 
 if __name__ == "__main__":

--- a/case_editor/src/test_capl_generator.py
+++ b/case_editor/src/test_capl_generator.py
@@ -1,0 +1,129 @@
+"""capl_generator 的离线测试：用构造的 .vsysvar + config + project.json 验证生成结果。"""
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+from capl_generator import generate_capl, parse_vsysvar, load_channel_mapping
+
+
+VSYSVAR = """<?xml version='1.0' encoding='utf-8'?>
+<systemvariables version="4">
+  <namespace name="" comment="" interface="">
+    <namespace name="control" comment="" interface="">
+      <variable anlyzLocal="2" readOnly="false" valueSequence="false" unit="" name="control_Node_On" comment="" bitcount="32" isSigned="false" encoding="65001" type="int" startValue="1" minValue="0" maxValue="1" />
+      <struct name="control_node_info" isUnion="False" definedBinaryLayout="False" comment="">
+        <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="IPB_MsgOn" comment="" bitcount="32" isSigned="false" encoding="65001" type="int" startValue="1" minValue="0" maxValue="1" />
+        <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="EPS_MsgOn" comment="" bitcount="32" isSigned="false" encoding="65001" type="int" startValue="1" minValue="0" maxValue="1" />
+      </struct>
+      <variable anlyzLocal="2" readOnly="false" valueSequence="false" unit="" name="control_Node_Info" comment="" bitcount="64" isSigned="true" encoding="65001" type="struct" structDefinition="control::control_node_info" />
+      <struct name="ipb_0x10c_info" isUnion="False" definedBinaryLayout="False" comment="">
+        <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="IPB_0x10C_MsgOn" comment="" bitcount="32" isSigned="false" encoding="65001" type="int" startValue="1" minValue="0" maxValue="1" />
+        <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="IPB_0x10C_MsgOff" comment="" bitcount="32" isSigned="false" encoding="65001" type="int" startValue="0" minValue="0" maxValue="1" />
+        <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="IPB_0x10C_MsgSendType" comment="" bitcount="32" isSigned="false" encoding="65001" type="int" startValue="0" minValue="0" maxValue="5" />
+        <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="IPB_0x10C_MsgCycleTime" comment="" bitcount="32" isSigned="false" encoding="65001" type="int" startValue="10" minValue="0" maxValue="65535" />
+      </struct>
+      <variable anlyzLocal="2" readOnly="false" valueSequence="false" unit="" name="IPB_0x10C_Info" comment="" bitcount="128" isSigned="true" encoding="65001" type="struct" structDefinition="control::ipb_0x10c_info" />
+      <struct name="ipb_0x10c" isUnion="False" definedBinaryLayout="False" comment="">
+        <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="IPB_0x10C_node" comment="" bitcount="0" isSigned="false" encoding="65001" type="string" startValue="IPB" />
+        <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="Checksum_10C_S_Pv" comment="" bitcount="32" isSigned="false" encoding="65001" type="int" startValue="0" minValue="0" maxValue="65535" />
+        <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="Checksum_10C_S_Rv" comment="" bitcount="32" isSigned="false" encoding="65001" type="int" startValue="0" minValue="0" maxValue="65535" />
+        <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="Checksum_10C_S_Factor" comment="" bitcount="64" isSigned="false" encoding="65001" type="float" startValue="1" />
+        <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="Checksum_10C_S_Offset" comment="" bitcount="64" isSigned="false" encoding="65001" type="float" startValue="0" />
+        <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="Counter_10C_S_Pv" comment="" bitcount="32" isSigned="false" encoding="65001" type="int" startValue="0" minValue="0" maxValue="15" />
+        <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="Counter_10C_S_Rv" comment="" bitcount="32" isSigned="false" encoding="65001" type="int" startValue="0" minValue="0" maxValue="15" />
+        <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="Counter_10C_S_Factor" comment="" bitcount="64" isSigned="false" encoding="65001" type="float" startValue="1" />
+        <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="Counter_10C_S_Offset" comment="" bitcount="64" isSigned="false" encoding="65001" type="float" startValue="0" />
+        <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="Vehicle_speed_Pv" comment="" bitcount="64" isSigned="false" encoding="65001" type="float" startValue="0" minValue="0" maxValue="281.4625" />
+        <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="Vehicle_speed_Rv" comment="" bitcount="32" isSigned="false" encoding="65001" type="int" startValue="0" minValue="0" maxValue="4094" />
+        <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="Vehicle_speed_Factor" comment="" bitcount="64" isSigned="false" encoding="65001" type="float" startValue="0.06875" />
+        <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="Vehicle_speed_Offset" comment="" bitcount="64" isSigned="false" encoding="65001" type="float" startValue="0" />
+        <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="Vehicle_speed_has_special_value" comment="" bitcount="32" isSigned="false" encoding="65001" type="int" startValue="0" minValue="0" maxValue="1" />
+        <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="Vehicle_speed_use_special_value" comment="" bitcount="32" isSigned="false" encoding="65001" type="int" startValue="0" minValue="0" maxValue="1" />
+        <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="Vehicle_speed_has_inactive_value" comment="" bitcount="32" isSigned="false" encoding="65001" type="int" startValue="1" minValue="0" maxValue="1" />
+        <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="Vehicle_speed_use_inactive_value" comment="" bitcount="32" isSigned="false" encoding="65001" type="int" startValue="0" minValue="0" maxValue="1" />
+        <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="Vehicle_speed_inactive_value" comment="" bitcount="32" isSigned="false" encoding="65001" type="int" startValue="4095" />
+      </struct>
+      <variable anlyzLocal="2" readOnly="false" valueSequence="false" unit="" name="IPB_0x10C" comment="" bitcount="512" isSigned="true" encoding="65001" type="struct" structDefinition="control::ipb_0x10c" />
+    </namespace>
+  </namespace>
+</systemvariables>
+"""
+
+
+def main():
+    base = Path("/tmp/test_capl/proj")
+    (base / "CANoe" / "dbc_file").mkdir(parents=True, exist_ok=True)
+
+    sysvar_path = base / "CANoe" / "system_variable" / "demo.vsysvar"
+    sysvar_path.parent.mkdir(parents=True, exist_ok=True)
+    sysvar_path.write_text(VSYSVAR, encoding="utf-8")
+
+    project_json = {
+        "canoe": {
+            "dbc_files": {
+                "CANoe/dbc_file/VCP_Control.dbc": {
+                    "path": "CANoe/dbc_file/VCP_Control.dbc",
+                    "short_name": "Control",
+                    "channel": 0,
+                }
+            }
+        }
+    }
+    (base / "project.json").write_text(json.dumps(project_json, ensure_ascii=False, indent=2), encoding="utf-8")
+
+    config = {
+        "dbc_configs": [
+            {
+                "dbc_path": "D:\\Test\\proj\\CANoe\\dbc_file\\VCP_Control.dbc",
+                "dbc_name": "control",
+                "center_node": "VCP",
+                "senders": [
+                    {
+                        "sender_node": "IPB",
+                        "messages": [
+                            {
+                                "message_name": "IPB_0x10C",
+                                "check_signal": "Checksum_10C_S",
+                                "counter_signal": "Counter_10C_S",
+                                "check_method": "crc16",
+                                "check_parameters": {
+                                    "poly": "0x1021",
+                                    "init": "0xFFFF",
+                                    "refIn": "false",
+                                    "refOut": "false",
+                                    "xorOut": "0x0000",
+                                },
+                            }
+                        ],
+                    }
+                ],
+            }
+        ],
+        "selected_system_variable_file": str(sysvar_path),
+    }
+
+    print("=== parse_vsysvar ===")
+    parsed = parse_vsysvar(str(sysvar_path))
+    msgs = parsed.messages
+    for name, model in msgs.items():
+        print(f"message {name}: signals = {[s.name for s in model.signals]}")
+        for s in model.signals:
+            print(f"  {s.name}: factor={s.factor} offset={s.offset} rv=[{s.rv_min},{s.rv_max}]"
+                  f" special={s.has_special_value} inactive={s.has_inactive_value}")
+
+    print("\n=== load_channel_mapping ===")
+    print(load_channel_mapping(base))
+
+    print("\n=== generate_capl ===")
+    files = generate_capl(config, base)
+    for f in files:
+        print("generated:", f)
+        print("-" * 60)
+        print(Path(f).read_text(encoding="utf-8"))
+
+
+if __name__ == "__main__":
+    main()

--- a/case_editor/src/test_capl_generator.py
+++ b/case_editor/src/test_capl_generator.py
@@ -47,6 +47,14 @@ VSYSVAR = """<?xml version='1.0' encoding='utf-8'?>
         <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="Vehicle_speed_inactive_value" comment="" bitcount="32" isSigned="false" encoding="65001" type="int" startValue="4095" />
       </struct>
       <variable anlyzLocal="2" readOnly="false" valueSequence="false" unit="" name="IPB_0x10C" comment="" bitcount="512" isSigned="true" encoding="65001" type="struct" structDefinition="control::ipb_0x10c" />
+      <struct name="ipb_0x200" isUnion="False" definedBinaryLayout="False" comment="">
+        <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="IPB_0x200_node" comment="" bitcount="0" isSigned="false" encoding="65001" type="string" startValue="IPB" />
+        <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="Wheel_speed_Pv" comment="" bitcount="64" isSigned="false" encoding="65001" type="float" startValue="0" minValue="0" maxValue="100" />
+        <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="Wheel_speed_Rv" comment="" bitcount="32" isSigned="false" encoding="65001" type="int" startValue="0" minValue="0" maxValue="200" />
+        <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="Wheel_speed_Factor" comment="" bitcount="64" isSigned="false" encoding="65001" type="float" startValue="0.5" />
+        <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="Wheel_speed_Offset" comment="" bitcount="64" isSigned="false" encoding="65001" type="float" startValue="0" />
+      </struct>
+      <variable anlyzLocal="2" readOnly="false" valueSequence="false" unit="" name="IPB_0x200" comment="" bitcount="256" isSigned="true" encoding="65001" type="struct" structDefinition="control::ipb_0x200" />
     </namespace>
   </namespace>
 </systemvariables>
@@ -86,6 +94,7 @@ def main():
                         "messages": [
                             {
                                 "message_name": "IPB_0x10C",
+                                "has_validation": True,
                                 "check_signal": "Checksum_10C_S",
                                 "counter_signal": "Counter_10C_S",
                                 "check_method": "crc16",
@@ -96,7 +105,11 @@ def main():
                                     "refOut": "false",
                                     "xorOut": "0x0000",
                                 },
-                            }
+                            },
+                            {
+                                "message_name": "IPB_0x200",
+                                "has_validation": False,
+                            },
                         ],
                     }
                 ],

--- a/case_editor/src/test_capl_generator.py
+++ b/case_editor/src/test_capl_generator.py
@@ -6,7 +6,13 @@ from pathlib import Path
 
 sys.path.insert(0, os.path.dirname(__file__))
 
-from capl_generator import generate_capl, parse_vsysvar, load_channel_mapping
+from capl_generator import (
+    generate_capl,
+    parse_vsysvar,
+    load_channel_mapping,
+    load_message_frame_ids,
+    _message_decl,
+)
 
 
 VSYSVAR = """<?xml version='1.0' encoding='utf-8'?>
@@ -70,6 +76,28 @@ VSYSVAR = """<?xml version='1.0' encoding='utf-8'?>
   </namespace>
 </systemvariables>
 """
+
+
+def test_message_decl_uses_dbc_frame_id(tmp_path=None):
+    """含 0x 的报文名应优先用 DBC 中的 CAN ID 声明 message。"""
+    import tempfile
+
+    dbc_text = (
+        'VERSION ""\n\n'
+        "NS_ :\n\n"
+        "BS_:\n\n"
+        "BU_: CIC\n\n"
+        "BO_ 659 CIC_0x293: 8 CIC\n"
+        ' SG_ Demo_Signal : 0|8@1+ (1,0) [0|255] "" Vector__XXX\n'
+    )
+    with tempfile.TemporaryDirectory() as tmp:
+        base = Path(tmp)
+        dbc_path = base / "CANoe" / "dbc_file" / "Control.dbc"
+        dbc_path.parent.mkdir(parents=True, exist_ok=True)
+        dbc_path.write_text(dbc_text, encoding="utf-8")
+        frame_ids = load_message_frame_ids(str(dbc_path), base)
+        assert frame_ids["CIC_0x293"] == 0x293
+        assert _message_decl("CIC_0x293", frame_ids["CIC_0x293"]) == "  message 0x293 msg_CIC_0x293;"
 
 
 def test_control_sample_vsysvar():
@@ -178,6 +206,8 @@ def main():
 
 
 if __name__ == "__main__":
+    test_message_decl_uses_dbc_frame_id()
+    print("=== test_message_decl_uses_dbc_frame_id passed ===")
     test_control_sample_vsysvar()
     print("=== test_control_sample_vsysvar passed ===")
     main()

--- a/case_editor/src/test_capl_generator.py
+++ b/case_editor/src/test_capl_generator.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 sys.path.insert(0, os.path.dirname(__file__))
 
-from capl_generator import generate_capl, parse_vsysvar, load_channel_mapping, _resolve_sig_send_types
+from capl_generator import generate_capl, parse_vsysvar, load_channel_mapping
 
 
 VSYSVAR = """<?xml version='1.0' encoding='utf-8'?>
@@ -81,9 +81,13 @@ def test_control_sample_vsysvar():
     assert model.info.has_wrong_crc_flag
     assert model.info.has_wrong_counter_flag
     assert signal.has_sig_send_type
-    assert signal.sig_send_type_choices[1] == "OnWrite"
-    assert signal.sig_send_type_choices[2] == "OnChange"
-    assert _resolve_sig_send_types(signal.sig_send_type_choices) == (0, 2, 1)
+    table = signal.sig_send_type
+    assert table.choices[1] == "OnWrite"
+    assert table.choices[2] == "OnChange"
+    assert table.cycle == 0
+    assert table.on_write == 1
+    assert table.on_change == 2
+    assert table.event == 3
 
 
 def main():

--- a/case_editor/src/test_capl_generator.py
+++ b/case_editor/src/test_capl_generator.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 sys.path.insert(0, os.path.dirname(__file__))
 
-from capl_generator import generate_capl, parse_vsysvar, load_channel_mapping
+from capl_generator import generate_capl, parse_vsysvar, load_channel_mapping, _resolve_sig_send_types
 
 
 VSYSVAR = """<?xml version='1.0' encoding='utf-8'?>
@@ -52,8 +52,8 @@ VSYSVAR = """<?xml version='1.0' encoding='utf-8'?>
         <structMember relativeOffset="0" byteOrder="0" isOptional="False" isHidden="False" name="Vehicle_speed_SigSendType" comment="" bitcount="32" isSigned="false" encoding="65001" type="int" startValue="0" minValue="0" maxValue="2">
           <valuetable defineMinMax="false" defineStartValue="false">
             <valuetableentry value="0" description="Cycle" />
-            <valuetableentry value="1" description="OnChange" />
-            <valuetableentry value="2" description="OnWrite" />
+            <valuetableentry value="1" description="OnWrite" />
+            <valuetableentry value="2" description="OnChange" />
           </valuetable>
         </structMember>
       </struct>
@@ -70,6 +70,20 @@ VSYSVAR = """<?xml version='1.0' encoding='utf-8'?>
   </namespace>
 </systemvariables>
 """
+
+
+def test_control_sample_vsysvar():
+    """用用户提供的 Control 网络样例验证解析与 SigSendType 映射。"""
+    fixture = Path(__file__).parent / "fixtures" / "control_ipb_sample.vsysvar"
+    parsed = parse_vsysvar(str(fixture))
+    model = parsed.messages["IPB_0x10C"]
+    signal = model.get("Vehicle_speed")
+    assert model.info.has_wrong_crc_flag
+    assert model.info.has_wrong_counter_flag
+    assert signal.has_sig_send_type
+    assert signal.sig_send_type_choices[1] == "OnWrite"
+    assert signal.sig_send_type_choices[2] == "OnChange"
+    assert _resolve_sig_send_types(signal.sig_send_type_choices) == (0, 2, 1)
 
 
 def main():
@@ -158,4 +172,6 @@ def main():
 
 
 if __name__ == "__main__":
+    test_control_sample_vsysvar()
+    print("=== test_control_sample_vsysvar passed ===")
     main()

--- a/case_editor/src/test_capl_generator.py
+++ b/case_editor/src/test_capl_generator.py
@@ -172,6 +172,8 @@ def main():
     assert "WrongCRCFlag" in capl_text
     assert "WrongCounterFlag" in capl_text
     assert "MsgNrOfRepetition" in capl_text
+    assert capl_text.count("on sysvar control::IPB_0x10C.Vehicle_speed_Pv") == 1
+    assert capl_text.count("on sysvar control::IPB_0x10C.Vehicle_speed_Rv") == 1
     print("\n=== assertions passed ===")
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 修复：CIC_0x293 等报文 message 声明编译失败

### 原因
`message CIC_0x293 msg_CIC_0x293;` 中 `0x293` 可能被 CAPL 词法分析当作十六进制字面量，导致报文名无法识别；或 DBC 符号名与生成名不一致。

`IPB_0x10C` 能编译通过，说明 DBC 已加载，但部分含 `0x` 的报文名仍可能触发该问题。

### 修复
生成器从项目 DBC 读取 `frame_id`，优先生成：

```capl
message 0x293 msg_CIC_0x293;
```

而非符号名 `message CIC_0x293 ...`。信号访问 `msg_CIC_0x293.Signal` 仍依赖 DBC 绑定。

### 使用注意
- `config` 中的 `dbc_path` 需指向项目内可读的 DBC 文件
- 若 DBC 中无该报文，会回退符号名并打印警告

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-53d36447-8860-4b1b-8c9f-1e28e6760a3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-53d36447-8860-4b1b-8c9f-1e28e6760a3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

